### PR TITLE
前日のミールを複製する機能を追加

### DIFF
--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -94,3 +94,7 @@
 // Delete confirmation
 "Delete All Data?" = "Delete All Data?";
 "Are you sure you want to delete all data? This action cannot be undone." = "Are you sure you want to delete all data? This action cannot be undone.";
+
+// Copy previous day meals
+"Copy yesterday's %@" = "Copy yesterday's %@";
+"Added %@ to %@" = "Added %@ to %@";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -128,3 +128,7 @@
 "Failed to delete data: " = "データの削除に失敗しました: ";
 "Deleting data..." = "データを削除中...";
 
+// Copy previous day meals
+"Copy yesterday's %@" = "昨日の%@をコピー";
+"Added %@ to %@" = "%@を%@に追加しました";
+


### PR DESCRIPTION
# 前日の食事コピー機能の追加

## 概要
前日と同じ食事内容を簡単に記録できるよう、前日の食事をコピーする機能を追加

## 変更内容
- 空の食事セクションに「昨日の[食事タイプ]をコピー」ボタンを表示
- 前日に同じ食事タイプのデータがある場合のみボタンを表示
- コピー時に食品マスターの使用頻度を適切に更新
- 多言語対応（日本語・英語）の追加

## 技術的な変更点
- `DayContentView.swift`に前日の食事データを取得・確認するメソッドを追加
- `previousDayItems(for:)` - 前日の特定食事タイプのアイテムを取得
- `hasPreviousDayItems(for:)` - 前日の食事データ存在確認
- `copyPreviousDayMeals(for:)` - 前日の食事を今日にコピー

## テスト内容
- 前日に食事データがある場合、空の食事セクションにコピーボタンが表示されることを確認
- 前日に食事データがない場合、コピーボタンが表示されないことを確認
- コピー機能で前日と同じ食事内容が正しく追加されることを確認
- FoodMasterの使用頻度が正しく更新されることを確認
- 多言語表示（日本語・英語）が正しく機能することを確認

