### PR TITLE
Fix item comparison and fiber label

### DIFF
--- a/BiteLog/Views/AddItemView.swift
+++ b/BiteLog/Views/AddItemView.swift
@@ -185,7 +185,7 @@ struct AddItemView: View {
         .buttonStyle(ScaleButtonStyle())
         .onAppear {
           // リストの最後のアイテムが表示されたら次のページを読み込む
-          if item == searchResults.last && hasMoreData && !isLoading {
+          if item.id == searchResults.last?.id && hasMoreData && !isLoading {
             loadMoreContent()
           }
         }

--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -158,7 +158,7 @@ struct ItemRowView: View {
           .font(.caption)
           .foregroundColor(.green)
 
-        Text("F: \(item.dietaryFiber, specifier: "%.1f")g")
+        Text("Fiber: \(item.dietaryFiber, specifier: "%.1f")g")
           .font(.caption)
           .foregroundColor(.brown)
 

--- a/BiteLog/Views/FoodMasterManagementView.swift
+++ b/BiteLog/Views/FoodMasterManagementView.swift
@@ -95,7 +95,7 @@ struct FoodMasterManagementView: View {
               }
               .onAppear {
                 // リストの最後のアイテムが表示されたら次のページを読み込む
-                if foodMaster == foodMasters.last && hasMoreData && !isLoading {
+                if foodMaster.id == foodMasters.last?.id && hasMoreData && !isLoading {
                   loadMoreContent()
                 }
               }


### PR DESCRIPTION
## Summary
- fix infinite paging conditions by comparing IDs when checking last item
- rename fiber row label in log item rows

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840b75bafd883209f746e89465a457c