### PR TITLE
複数のログアイテムを一括削除できる機能を追加

### DIFF
--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -98,3 +98,6 @@
 // Copy previous day meals
 "Copy yesterday's %@" = "Copy yesterday's %@";
 "Added %@ to %@" = "Added %@ to %@";
+
+// Delete multiple items
+"Delete %d items" = "Delete %d items";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -132,3 +132,6 @@
 "Copy yesterday's %@" = "昨日の%@をコピー";
 "Added %@ to %@" = "%@を%@に追加しました";
 
+// Delete multiple items
+"Delete %d items" = "%d件を削除";
+

--- a/BiteLog/Views/DayContentView.swift
+++ b/BiteLog/Views/DayContentView.swift
@@ -45,20 +45,16 @@ struct DayContentView: View {
           }
         }
         
-        ToolbarItem(placement: .bottomBar) {
+        ToolbarItem(placement: .navigationBarLeading) {
           if editMode == .active && !selectedItemIDs.isEmpty {
-            HStack {
-              Button(action: {
-                deleteSelectedItems()
-              }) {
-                Label(
-                  String(format: NSLocalizedString("Delete %d items", comment: "Delete multiple items"), selectedItemIDs.count),
-                  systemImage: "trash"
-                )
-                .foregroundColor(.red)
-              }
-              
-              Spacer()
+            Button(action: {
+              deleteSelectedItems()
+            }) {
+              Label(
+                String(format: NSLocalizedString("Delete %d items", comment: "Delete multiple items"), selectedItemIDs.count),
+                systemImage: "trash"
+              )
+              .foregroundColor(.red)
             }
           }
         }
@@ -258,7 +254,7 @@ struct DayContentView: View {
                   onAddTapped(date, mealType)
                 }
               } else {
-                List(selection: $selectedItemIDs) {
+                List(selection: editMode == .active ? $selectedItemIDs : .constant(Set<PersistentIdentifier>())) {
                   ForEach(mealItems, id: \.persistentModelID) { item in
                     ItemRowView(item: item)
                       .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
@@ -414,20 +410,18 @@ struct DayContentView: View {
   
   // 選択されたアイテムを削除する
   private func deleteSelectedItems() {
-    print("Selected item IDs count: \(selectedItemIDs.count)")
-    
     // 選択されたIDに対応するアイテムを取得
-    let itemsToDelete = filteredItems.filter { item in
+    let itemsToDelete = dayLogItems.filter { item in
       selectedItemIDs.contains(item.persistentModelID)
     }
     
     if itemsToDelete.isEmpty {
-      print("No items found for deletion")
       return
     }
     
-    print("Deleting \(itemsToDelete.count) items")
+    // deleteItems関数を再利用
     deleteItems(itemsToDelete)
+    
     selectedItemIDs.removeAll()
     editMode = .inactive
   }


### PR DESCRIPTION
## Summary
- DayContentViewに編集モードを追加し、複数のログアイテムを選択して一括削除できるようにしました
- 削除ボタンはナビゲーションバー左側に配置し、選択数を表示します
- 英語と日本語のローカライズに対応しました

## Test plan
- [ ] 編集ボタンをタップして編集モードに入れることを確認
- [ ] 編集モード中に複数のアイテムを選択できることを確認
- [ ] 選択したアイテム数が削除ボタンに正しく表示されることを確認
- [ ] 削除ボタンをタップして選択したアイテムが削除されることを確認
- [ ] スワイプ削除が引き続き機能することを確認
- [ ] 削除時にFoodMasterの使用頻度が正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)