### PR TITLE
Fix Info.plist configuration for build error

### DIFF
--- a/BiteLog.xcodeproj/project.pbxproj
+++ b/BiteLog.xcodeproj/project.pbxproj
@@ -408,8 +408,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"BiteLog/Preview Content\"";
 				DEVELOPMENT_TEAM = L3VU6Q2MZ6;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = BiteLog/Info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -440,8 +439,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"BiteLog/Preview Content\"";
 				DEVELOPMENT_TEAM = L3VU6Q2MZ6;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = BiteLog/Info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
## Summary
- Info.plist設定を修正してビルドエラーを解決

## Problem
ビルド時に以下のエラーが発生:
```
Build input file cannot be found: '/Users/watahikishinya/projects/BiteLog/BiteLog/Info.plist'
```

## Solution
- `GENERATE_INFOPLIST_FILE = YES`に設定し、Xcodeが自動的にInfo.plistを生成するように修正
- 手動のInfo.plistファイルへの参照を削除

## Test plan
- [ ] プロジェクトが正常にビルドできることを確認
- [ ] アプリが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)