### PR TITLE
Add GitHub Pages marketing website for App Store

### DIFF
--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-3786393697724703, DIRECT, f08c47fec0942fa0

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,0 +1,390 @@
+/* BiteLog Website Styles */
+
+/* Reset and Base Styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #fafafa;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header */
+.header {
+    background: #fff;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.header .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 20px;
+}
+
+.logo {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #2c5530;
+    text-decoration: none;
+}
+
+.logo a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.nav {
+    display: flex;
+    gap: 2rem;
+}
+
+.nav a {
+    text-decoration: none;
+    color: #333;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.nav a:hover {
+    color: #2c5530;
+}
+
+/* Hero Section */
+.hero {
+    background: linear-gradient(135deg, #2c5530 0%, #4a7c59 100%);
+    color: #fff;
+    padding: 4rem 0;
+    text-align: center;
+}
+
+.hero-title {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    line-height: 1.2;
+}
+
+.hero-description {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+}
+
+.hero-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+/* Buttons */
+.btn {
+    display: inline-block;
+    padding: 0.8rem 2rem;
+    border-radius: 25px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    border: 2px solid transparent;
+}
+
+.btn-primary {
+    background: #fff;
+    color: #2c5530;
+}
+
+.btn-primary:hover {
+    background: #f0f0f0;
+    transform: translateY(-2px);
+}
+
+.btn-secondary {
+    background: transparent;
+    color: #fff;
+    border-color: #fff;
+}
+
+.btn-secondary:hover {
+    background: #fff;
+    color: #2c5530;
+    transform: translateY(-2px);
+}
+
+/* Features Section */
+.features {
+    padding: 4rem 0;
+}
+
+.section-title {
+    text-align: center;
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #2c5530;
+    margin-bottom: 3rem;
+}
+
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+}
+
+.feature-card {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 15px;
+    text-align: center;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-5px);
+}
+
+.feature-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.feature-card h3 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: #2c5530;
+    margin-bottom: 1rem;
+}
+
+.feature-card p {
+    color: #666;
+    line-height: 1.6;
+}
+
+/* Download Section */
+.download {
+    background: #f8f9fa;
+    padding: 4rem 0;
+    text-align: center;
+}
+
+.download-description {
+    font-size: 1.1rem;
+    color: #666;
+    margin-bottom: 2rem;
+}
+
+.coming-soon {
+    display: inline-block;
+    padding: 1rem 2rem;
+    background: #e9ecef;
+    color: #6c757d;
+    border-radius: 25px;
+    font-weight: 600;
+    border: 2px solid #dee2e6;
+}
+
+/* Contact Section */
+.contact {
+    padding: 4rem 0;
+    text-align: center;
+}
+
+.contact-content p {
+    font-size: 1.1rem;
+    color: #666;
+    margin-bottom: 2rem;
+}
+
+/* Footer */
+.footer {
+    background: #2c5530;
+    color: #fff;
+    padding: 3rem 0 1rem;
+}
+
+.footer-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.footer-section h3 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.footer-section h4 {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+}
+
+.footer-section ul {
+    list-style: none;
+}
+
+.footer-section li {
+    margin-bottom: 0.5rem;
+}
+
+.footer-section a {
+    color: #fff;
+    text-decoration: none;
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.footer-section a:hover {
+    opacity: 1;
+}
+
+.footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+    padding-top: 1rem;
+    text-align: center;
+    opacity: 0.8;
+}
+
+/* Policy Pages */
+.policy-content {
+    max-width: 800px;
+    margin: 2rem auto;
+    background: #fff;
+    padding: 3rem;
+    border-radius: 10px;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+}
+
+.policy-content h1 {
+    color: #2c5530;
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+}
+
+.last-updated {
+    color: #666;
+    font-style: italic;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.policy-content section {
+    margin-bottom: 2rem;
+}
+
+.policy-content h2 {
+    color: #2c5530;
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+    margin-top: 2rem;
+}
+
+.policy-content h3 {
+    color: #4a7c59;
+    font-size: 1.2rem;
+    margin-bottom: 0.5rem;
+    margin-top: 1.5rem;
+}
+
+.policy-content ul {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.policy-content li {
+    margin-bottom: 0.5rem;
+}
+
+.policy-content a {
+    color: #2c5530;
+    text-decoration: underline;
+}
+
+.policy-content a:hover {
+    color: #4a7c59;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header .container {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .nav {
+        gap: 1rem;
+    }
+    
+    .hero-title {
+        font-size: 2rem;
+    }
+    
+    .hero-description {
+        font-size: 1rem;
+    }
+    
+    .hero-buttons {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .section-title {
+        font-size: 2rem;
+    }
+    
+    .features-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .policy-content {
+        margin: 1rem;
+        padding: 2rem 1.5rem;
+    }
+    
+    .policy-content h1 {
+        font-size: 2rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        padding: 0 15px;
+    }
+    
+    .hero {
+        padding: 3rem 0;
+    }
+    
+    .hero-title {
+        font-size: 1.8rem;
+    }
+    
+    .btn {
+        padding: 0.7rem 1.5rem;
+    }
+    
+    .features,
+    .download,
+    .contact {
+        padding: 3rem 0;
+    }
+    
+    .policy-content {
+        padding: 1.5rem 1rem;
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BiteLog - 食事記録アプリ</title>
+    <meta name="description" content="BiteLog - 毎日の食事を簡単に記録し、栄養管理ができるiOSアプリです。">
+    <meta name="keywords" content="食事記録,栄養管理,カロリー計算,健康管理,iOS,アプリ">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <h1 class="logo">🍽️ BiteLog</h1>
+            <nav class="nav">
+                <a href="#features">機能</a>
+                <a href="#download">ダウンロード</a>
+                <a href="#contact">お問い合わせ</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <h2 class="hero-title">毎日の食事を<br>もっと健康的に</h2>
+                <p class="hero-description">
+                    BiteLogは、食事記録と栄養管理を簡単に行えるiOSアプリです。<br>
+                    日々の食事を記録し、栄養バランスをチェックしましょう。
+                </p>
+                <div class="hero-buttons">
+                    <a href="#download" class="btn btn-primary">今すぐダウンロード</a>
+                    <a href="#features" class="btn btn-secondary">機能を見る</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="features" class="features">
+            <div class="container">
+                <h2 class="section-title">主な機能</h2>
+                <div class="features-grid">
+                    <div class="feature-card">
+                        <div class="feature-icon">📝</div>
+                        <h3>簡単食事記録</h3>
+                        <p>食品を選んで分量を入力するだけで、簡単に食事を記録できます。</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">📊</div>
+                        <h3>栄養成分表示</h3>
+                        <p>カロリー、タンパク質、脂質、糖質、食物繊維の情報を自動計算。</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">📅</div>
+                        <h3>日別管理</h3>
+                        <p>朝食、昼食、夕食、間食に分けて食事を管理できます。</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">🥗</div>
+                        <h3>食品マスター</h3>
+                        <p>よく使う食品を登録して、効率的に食事記録を行えます。</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">📈</div>
+                        <h3>データエクスポート</h3>
+                        <p>記録したデータをCSV形式でエクスポートして分析できます。</p>
+                    </div>
+                    <div class="feature-card">
+                        <div class="feature-icon">🌏</div>
+                        <h3>多言語対応</h3>
+                        <p>日本語と英語に対応し、お好みの言語で利用できます。</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="download" class="download">
+            <div class="container">
+                <h2 class="section-title">ダウンロード</h2>
+                <p class="download-description">
+                    BiteLogは現在開発中です。App Storeでの公開をお待ちください。
+                </p>
+                <div class="download-button">
+                    <span class="coming-soon">Coming Soon on App Store</span>
+                </div>
+            </div>
+        </section>
+
+        <section id="contact" class="contact">
+            <div class="container">
+                <h2 class="section-title">お問い合わせ・サポート</h2>
+                <div class="contact-content">
+                    <p>
+                        アプリに関するご質問やサポートが必要な場合は、<br>
+                        GitHubのIssuesページからお気軽にお問い合わせください。
+                    </p>
+                    <a href="https://github.com/watahiki606/BiteLog/issues" class="btn btn-primary" target="_blank">
+                        GitHubでお問い合わせ
+                    </a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>BiteLog</h3>
+                    <p>健康的な食生活をサポートする食事記録アプリ</p>
+                </div>
+                <div class="footer-section">
+                    <h4>リンク</h4>
+                    <ul>
+                        <li><a href="privacy.html">プライバシーポリシー</a></li>
+                        <li><a href="terms.html">利用規約</a></li>
+                        <li><a href="https://github.com/watahiki606/BiteLog" target="_blank">GitHub</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 BiteLog. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>プライバシーポリシー - BiteLog</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <h1 class="logo"><a href="index.html">🍽️ BiteLog</a></h1>
+            <nav class="nav">
+                <a href="index.html">ホーム</a>
+                <a href="index.html#features">機能</a>
+                <a href="index.html#contact">お問い合わせ</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <div class="policy-content">
+                <h1>プライバシーポリシー</h1>
+                <p class="last-updated">最終更新日：2024年12月29日</p>
+
+                <section>
+                    <h2>1. はじめに</h2>
+                    <p>
+                        本プライバシーポリシーは、BiteLog（以下「本アプリ」）をご利用いただく際の、
+                        お客様の個人情報の取り扱いについて説明するものです。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>2. 収集する情報</h2>
+                    <h3>2.1 個人情報</h3>
+                    <p>
+                        本アプリは、お客様の個人を特定できる情報（氏名、メールアドレス、電話番号等）を
+                        収集いたしません。
+                    </p>
+                    
+                    <h3>2.2 食事記録データ</h3>
+                    <p>
+                        本アプリで記録された食事データ（食品名、摂取量、栄養成分等）は、
+                        お客様のデバイス内のみに保存され、外部サーバーには送信されません。
+                    </p>
+
+                    <h3>2.3 使用状況データ</h3>
+                    <p>
+                        アプリの改善のため、匿名化された使用状況データ（クラッシュレポート、
+                        機能の利用頻度等）を収集する場合があります。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>3. データの使用目的</h2>
+                    <p>収集したデータは以下の目的でのみ使用いたします：</p>
+                    <ul>
+                        <li>アプリの機能提供</li>
+                        <li>アプリの品質向上・改善</li>
+                        <li>技術的問題の解決</li>
+                        <li>法的要求への対応</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>4. データの共有</h2>
+                    <p>
+                        お客様の食事記録データを第三者と共有することはありません。
+                        ただし、以下の場合を除きます：
+                    </p>
+                    <ul>
+                        <li>お客様の明示的な同意がある場合</li>
+                        <li>法的義務に基づく場合</li>
+                        <li>お客様や公衆の安全を守るために必要な場合</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>5. データの保存</h2>
+                    <p>
+                        食事記録データは、お客様のデバイス内のみに保存されます。
+                        アプリを削除すると、すべてのデータが削除されます。
+                        データのバックアップはお客様ご自身で行ってください。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>6. セキュリティ</h2>
+                    <p>
+                        お客様のデータの安全性を確保するため、適切な技術的・組織的措置を講じています。
+                        ただし、インターネット上の情報伝達において完全なセキュリティを保証することはできません。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>7. お客様の権利</h2>
+                    <p>お客様には以下の権利があります：</p>
+                    <ul>
+                        <li>データの確認・修正・削除</li>
+                        <li>データの使用停止要求</li>
+                        <li>本ポリシーに関する質問</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>8. 子どものプライバシー</h2>
+                    <p>
+                        本アプリは13歳未満の子どもから意図的に個人情報を収集することはありません。
+                        13歳未満の子どもの個人情報を収集したことが判明した場合、
+                        速やかに削除いたします。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>9. ポリシーの変更</h2>
+                    <p>
+                        本プライバシーポリシーは予告なく変更される場合があります。
+                        重要な変更がある場合は、アプリ内で通知いたします。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>10. お問い合わせ</h2>
+                    <p>
+                        本プライバシーポリシーに関するご質問は、
+                        <a href="https://github.com/watahiki606/BiteLog/issues" target="_blank">
+                            GitHubのIssuesページ
+                        </a>
+                        からお問い合わせください。
+                    </p>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>BiteLog</h3>
+                    <p>健康的な食生活をサポートする食事記録アプリ</p>
+                </div>
+                <div class="footer-section">
+                    <h4>リンク</h4>
+                    <ul>
+                        <li><a href="index.html">ホーム</a></li>
+                        <li><a href="privacy.html">プライバシーポリシー</a></li>
+                        <li><a href="terms.html">利用規約</a></li>
+                        <li><a href="https://github.com/watahiki606/BiteLog" target="_blank">GitHub</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 BiteLog. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>利用規約 - BiteLog</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <div class="container">
+            <h1 class="logo"><a href="index.html">🍽️ BiteLog</a></h1>
+            <nav class="nav">
+                <a href="index.html">ホーム</a>
+                <a href="index.html#features">機能</a>
+                <a href="index.html#contact">お問い合わせ</a>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <div class="policy-content">
+                <h1>利用規約</h1>
+                <p class="last-updated">最終更新日：2024年12月29日</p>
+
+                <section>
+                    <h2>1. はじめに</h2>
+                    <p>
+                        本利用規約（以下「本規約」）は、BiteLog（以下「本アプリ」）の利用に関する
+                        条件を定めるものです。本アプリをご利用いただく際には、
+                        本規約にご同意いただく必要があります。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>2. 利用許諾</h2>
+                    <p>
+                        本規約に従い、お客様に本アプリを使用する非独占的、
+                        譲渡不可能なライセンスを付与します。
+                        本アプリは個人的な非商用目的でのみご利用ください。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>3. 禁止事項</h2>
+                    <p>本アプリをご利用の際、以下の行為を禁止いたします：</p>
+                    <ul>
+                        <li>本アプリの逆アセンブル、逆コンパイル、リバースエンジニアリング</li>
+                        <li>本アプリの複製、配布、貸与、販売、移転</li>
+                        <li>本アプリの改変、修正</li>
+                        <li>違法な目的での使用</li>
+                        <li>他の利用者や第三者に迷惑をかける行為</li>
+                        <li>システムに負荷をかける行為</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2>4. データの取り扱い</h2>
+                    <p>
+                        お客様が本アプリに入力したデータ（食事記録等）の所有権は
+                        お客様に帰属します。本アプリの開発者は、
+                        お客様のデータに対していかなる権利も主張いたしません。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>5. 免責事項</h2>
+                    <h3>5.1 サービスの提供</h3>
+                    <p>
+                        本アプリは「現状のまま」提供され、明示または黙示を問わず、
+                        いかなる保証もいたしません。
+                    </p>
+
+                    <h3>5.2 健康・医療に関する免責</h3>
+                    <p>
+                        本アプリが提供する栄養情報は参考情報であり、
+                        医学的なアドバイスではありません。健康に関する決定を行う前に、
+                        医師や栄養士等の専門家にご相談ください。
+                    </p>
+
+                    <h3>5.3 損害の免責</h3>
+                    <p>
+                        本アプリの使用により生じたいかなる直接的、間接的、
+                        特別、偶発的、結果的損害についても責任を負いません。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>6. サービスの変更・終了</h2>
+                    <p>
+                        本アプリの開発者は、予告なく本アプリの機能の変更、追加、削除、
+                        またはサービスの終了を行う場合があります。
+                        これらによりお客様に生じた損害について責任を負いません。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>7. 知的財産権</h2>
+                    <p>
+                        本アプリに関するすべての知的財産権は、開発者または
+                        正当な権利者に帰属します。本規約は、これらの権利を
+                        お客様に譲渡するものではありません。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>8. 準拠法・管轄裁判所</h2>
+                    <p>
+                        本規約は日本法に準拠し、解釈されるものとします。
+                        本アプリに関連する紛争については、
+                        東京地方裁判所を専属的合意管轄裁判所とします。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>9. 規約の変更</h2>
+                    <p>
+                        本規約は予告なく変更される場合があります。
+                        変更後も継続して本アプリをご利用いただく場合、
+                        変更後の規約に同意したものとみなします。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>10. 分離可能性</h2>
+                    <p>
+                        本規約の一部が無効または執行不能と判断された場合でも、
+                        その他の規定は引き続き有効に存続するものとします。
+                    </p>
+                </section>
+
+                <section>
+                    <h2>11. お問い合わせ</h2>
+                    <p>
+                        本規約に関するご質問は、
+                        <a href="https://github.com/watahiki606/BiteLog/issues" target="_blank">
+                            GitHubのIssuesページ
+                        </a>
+                        からお問い合わせください。
+                    </p>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>BiteLog</h3>
+                    <p>健康的な食生活をサポートする食事記録アプリ</p>
+                </div>
+                <div class="footer-section">
+                    <h4>リンク</h4>
+                    <ul>
+                        <li><a href="index.html">ホーム</a></li>
+                        <li><a href="privacy.html">プライバシーポリシー</a></li>
+                        <li><a href="terms.html">利用規約</a></li>
+                        <li><a href="https://github.com/watahiki606/BiteLog" target="_blank">GitHub</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 BiteLog. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- GitHub Pagesマーケティングサイトを作成
- App Store登録に必要なプライバシーポリシーと利用規約を追加
- Google AdMob認証用のapp-ads.txtファイルを追加

## Changes
- `docs/index.html` - メインのランディングページ
- `docs/privacy.html` - プライバシーポリシー
- `docs/terms.html` - 利用規約
- `docs/css/style.css` - レスポンシブデザイン対応のスタイルシート
- `docs/app-ads.txt` - AdMob認証用ファイル

## Setup Instructions
1. GitHub リポジトリ設定でPagesを有効化
2. Sourceを`github-pages`ブランチの`/docs`フォルダに設定
3. 公開URL: `https://watahiki606.github.io/BiteLog/`

## Test plan
- [ ] GitHub Pagesの設定を有効化
- [ ] 各ページが正しく表示されることを確認
- [ ] モバイルレスポンシブデザインの確認
- [ ] app-ads.txtがアクセス可能であることを確認
- [ ] AdMobでアプリ認証が完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)