### PR TITLE
feat: Implement seamless quick food creation workflow

### DIFF
--- a/BiteLog.xcodeproj/project.pbxproj
+++ b/BiteLog.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.watahiki.BiteLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -442,7 +442,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.watahiki.BiteLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -101,3 +101,14 @@
 
 // Delete multiple items
 "Delete %d items" = "Delete %d items";
+
+// Quick food creation
+"Create and add \"%@\"" = "Create and add \"%@\"";
+"Quickly add a new food item" = "Quickly add a new food item";
+"Quick Add Food" = "Quick Add Food";
+"Food Information" = "Food Information";
+"Nutrition per Serving" = "Nutrition per Serving";
+"Portion Unit" = "Portion Unit";
+"servings" = "servings";
+"Unknown" = "Unknown";
+"or" = "or";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -135,3 +135,14 @@
 // Delete multiple items
 "Delete %d items" = "%d件を削除";
 
+// Quick food creation
+"Create and add \"%@\"" = "「%@」を作成して追加";
+"Quickly add a new food item" = "新しいフードを素早く追加";
+"Quick Add Food" = "フードを素早く追加";
+"Food Information" = "フード情報";
+"Nutrition per Serving" = "1食分の栄養成分";
+"Portion Unit" = "分量の単位";
+"servings" = "食";
+"Unknown" = "不明";
+"or" = "または";
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ SweetPad: Generate Build Server Config
 - Bundle ID: `com.watahiki.BiteLog`
 - Minimum iOS version: iOS 18.2
 - Supported devices: iPhone only
-- Current version: 1.3
+- Current version: 1.6
 
 ## Testing Strategy
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5</string>
+    <string>1.6</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
## Summary

Implements a streamlined food creation workflow that allows users to create and add new food items directly from the search interface without manual navigation.

- Add "Create and add [search term]" button when no search results are found
- Integrate enhanced FoodMasterFormView with quick creation mode
- Implement automatic return to Log screen after creation
- Add state persistence to prevent data loss during app switching

## Key Features

### 🚀 Seamless UX Flow
1. User searches for food item
2. If not found, "Create and add" button appears
3. One tap opens creation form with search term pre-filled
4. After creation, automatically returns to Log screen with item added

### 💾 State Persistence
- UserDefaults-based persistence prevents input loss during app switching
- Only applies to quick creation mode to avoid unnecessary storage
- Automatic cleanup after successful creation

### 🔧 Technical Improvements
- Enhanced FoodMasterFormView with quickAdd mode and callback support
- Removed Portion Unit default value for cleaner UX
- Proper state management for form restoration

## Test Plan

- [ ] Search for non-existent food item
- [ ] Verify "Create and add" button appears
- [ ] Test creation form with pre-filled search term
- [ ] Verify automatic return to Log screen after creation
- [ ] Test state persistence by switching apps during creation
- [ ] Verify Portion Unit field starts empty
- [ ] Test creation with minimal required fields
- [ ] Verify successful LogItem creation after food creation

🤖 Generated with [Claude Code](https://claude.ai/code)