### PR TITLE
refactor: Apply adaptive formatting to calories

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh api graphql:*)",
+      "Bash(xcodebuild:*)",
+      "Bash(rm:*)",
+      "Bash(rg:*)",
+      "Bash(/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg -A 30 \"struct ItemRowView\" --type swift)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh issue create:*)",
+      "WebFetch(domain:developers.google.com)",
+      "mcp__ide__getDiagnostics",
+      "Bash(echo $?)",
+      "WebFetch(domain:stackoverflow.com)",
+      "Bash(sed:*)",
+      "WebFetch(domain:developer.apple.com)",
+      "Bash(gemini:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr create --title \"feat: Increase nutrition display precision to 3 decimal places\" --body \"$(cat <<''EOF''\n## Summary\n- Changed nutrition display precision from 1 decimal place to 3 decimal places\n- Applies to: protein, fat, sugar, dietary fiber, carbohydrates, and servings\n- Calories remain as integer display (no change)\n\n## Changes\n- **ContentView.swift**: Updated ItemRowView and MacroView nutrition formats\n- **FoodMasterManagementView.swift**: Updated FoodMasterRow and form display\n- **DayContentView.swift**: Updated daily summary nutrition display\n- **AddItemView.swift**: Updated servings display precision\n- **CommonComponents.swift**: Updated MacroNutrientBadge component\n- **EditItemView.swift**: Updated servings initial value format\n\n## Motivation\nProvides more accurate nutrition tracking for users who need precise measurements.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\" --base main)",
+      "Bash(gh pr diff:*)",
+      "Bash(xcbeautify:*)",
+      "Bash(gh pr create:*)"
+    ],
+    "deny": [],
+    "env": {
+      "MAX_THINKING_TOKENS": "31999"
+    }
+  }
+}

--- a/BiteLog/Utilities/NutritionFormatter.swift
+++ b/BiteLog/Utilities/NutritionFormatter.swift
@@ -23,12 +23,4 @@ enum NutritionFormatter {
       return String(format: "%.3f", value)
     }
   }
-
-  /// カロリー用のフォーマット（常に整数表示）
-  ///
-  /// - Parameter value: フォーマットする数値
-  /// - Returns: フォーマットされた文字列
-  static func formatCalories(_ value: Double) -> String {
-    return String(format: "%.0f", value)
-  }
 }

--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -226,12 +226,8 @@ struct NutrientRow: View {
   }
 
   private var formattedValue: String {
-    // カロリーの場合は整数表示、それ以外は適応的フォーマット
-    if unit == "kcal" {
-      return NutritionFormatter.formatCalories(value)
-    } else {
-      return NutritionFormatter.formatNutrition(value)
-    }
+    // すべての栄養素に適応的フォーマットを使用
+    return NutritionFormatter.formatNutrition(value)
   }
 }
 

--- a/BiteLog/Views/FoodMasterManagementView.swift
+++ b/BiteLog/Views/FoodMasterManagementView.swift
@@ -647,7 +647,7 @@ struct FoodMasterFormView: View {
       // 編集モードの場合、既存の値をフォームにセット
       brandName = foodMaster.brandName
       productName = foodMaster.productName
-      calories = NutritionFormatter.formatCalories(foodMaster.calories)
+      calories = NutritionFormatter.formatNutrition(foodMaster.calories)
       sugar = NutritionFormatter.formatNutrition(foodMaster.sugar)
       dietaryFiber = NutritionFormatter.formatNutrition(foodMaster.dietaryFiber)
       fat = NutritionFormatter.formatNutrition(foodMaster.fat)


### PR DESCRIPTION
Changed calories to use the same adaptive formatting as other nutrients:
- Integer calories display without decimals (e.g., "150")
- Decimal calories display with appropriate precision (e.g., "150.5" or "150.234")

Removed formatCalories() method from NutritionFormatter as it's no longer needed. All nutrition values now consistently use formatNutrition() for adaptive display.

Updated views:
- ContentView: NutrientRow now uses formatNutrition for all values including calories
- FoodMasterManagementView: Edit mode calories now use formatNutrition

🤖 Generated with [Claude Code](https://claude.com/claude-code)