### PR TITLE
fix: バナー広告のSafe Area対応

### DIFF
--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -106,10 +106,10 @@ struct ContentView: View {
     // 固定バナー広告
     AdaptiveBannerView()
       .frame(height: 50)
+      .padding(.bottom, 20)
       .background(Color(UIColor.systemBackground))
       .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: -2)
     }
-    .edgesIgnoringSafeArea(.bottom)
   }
 
   private var dateFormatter: DateFormatter {


### PR DESCRIPTION
## 概要
画面下部のバナー広告が画面の下端に食い込んで表示される問題を修正しました。

## 変更内容
- `.edgesIgnoringSafeArea(.bottom)`を削除してSafe Areaを尊重するように変更
- `.padding(.bottom, 20)`を追加してバナー下部に余白を確保
- バナーの角が見切れることなく完全に表示されるように調整

## 修正理由
iPhoneのホームインジケーター(画面下部の横線)とバナーが重なり、バナーの下端の両端が見えなくなっていました。Safe Area内に適切に配置することで、バナーが綺麗に表示されるようになり、ユーザー体験が向上します。

## 影響範囲
- `ContentView.swift`のバナー表示部分のみ
- 既存の機能には影響なし

## テスト
- [ ] iPhone実機でバナーが画面下端に食い込まず表示されることを確認
- [ ] バナーの角が完全に表示されることを確認
- [ ] ホームインジケーターとバナーが重ならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)