### PR TITLE
chore: Bump version to 2.0 in project settings and Info.plist

### DIFF
--- a/BiteLog.xcodeproj/project.pbxproj
+++ b/BiteLog.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 2.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.watahiki.BiteLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -442,7 +442,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 2.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.watahiki.BiteLog;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.9</string>
+    <string>2.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Updated MARKETING_VERSION in project.pbxproj and CFBundleShortVersionString in Info.plist to reflect the new version 2.0.