### PR TITLE
feat: データモデル再設計とportionSize導入

### DIFF
--- a/BiteLog/App/BiteLogApp.swift
+++ b/BiteLog/App/BiteLogApp.swift
@@ -4,7 +4,6 @@ import SwiftUI
 @main
 struct BiteLogApp: App {
   @StateObject private var languageManager = LanguageManager()
-  @StateObject private var nutritionGoalsManager = NutritionGoalsManager()
 
   init() {
     // AdMob初期化（SDK v12対応済み）
@@ -16,6 +15,7 @@ struct BiteLogApp: App {
     let schema = Schema([
       FoodMaster.self,
       LogItem.self,
+      NutritionGoals.self,
     ])
     let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
@@ -32,7 +32,11 @@ struct BiteLogApp: App {
         .tint(Color.accentColor)
         .environment(\.locale, languageManager.locale)
         .environmentObject(languageManager)
-        .environmentObject(nutritionGoalsManager)
+        .environmentObject(
+          NutritionGoalsManager(
+            modelContext: sharedModelContainer.mainContext
+          )
+        )
         .id(languageManager.selectedLanguage)
         .onAppear {
           // App Tracking Transparencyのリクエスト

--- a/BiteLog/Models/FoodMaster.swift
+++ b/BiteLog/Models/FoodMaster.swift
@@ -6,67 +6,69 @@ final class FoodMaster {
   #Index<FoodMaster>(
     [\.usageCount, \.lastUsedDate, \.productName])
 
-  @Attribute(.unique) var id: UUID  // ユニークIDを追加
+  @Attribute(.unique) var id: UUID
   var brandName: String
   var productName: String
   var calories: Double
-  var dietaryFiber: Double  // 食物繊維を追加
-  var sugar: Double  // 糖質を追加
+  var dietaryFiber: Double
+  var netCarbs: Double
   var fat: Double
   var protein: Double
+  var portionSize: Double
   var portionUnit: String
-  var portion: Double  // 数量を表すので Double 型に変更
-  @Attribute(.unique) var uniqueKey: String  // 栄養素に基づく一意キー
+  @Attribute(.unique) var uniqueKey: String
 
   // 使用頻度関連のプロパティ
-  var usageCount: Int = 0  // 使用回数
-  var lastUsedDate: Date?  // 最後に使用された日時
-  var lastNumberOfServings: Double = 1.0  // 最後に使用したサービング数
+  var usageCount: Int = 0
+  var lastUsedDate: Date?
+  var lastNumberOfServings: Double = 1.0
 
   // 炭水化物は食物繊維と糖質の合計として計算
   var carbohydrates: Double {
-    return sugar + dietaryFiber
+    return netCarbs + dietaryFiber
   }
 
   init(
     id: UUID = UUID(), brandName: String, productName: String, calories: Double,
-    sugar: Double, dietaryFiber: Double, fat: Double, protein: Double, portionUnit: String,
-    portion: Double
+    netCarbs: Double, dietaryFiber: Double, fat: Double, protein: Double,
+    portionSize: Double = 1.0, portionUnit: String
   ) {
     self.id = id
     self.brandName = brandName
     self.productName = productName
     self.calories = calories
-    self.sugar = sugar
+    self.netCarbs = netCarbs
     self.dietaryFiber = dietaryFiber
     self.fat = fat
     self.protein = protein
+    self.portionSize = portionSize
     self.portionUnit = portionUnit
-    self.portion = portion
-    self.lastNumberOfServings = 1.0  // デフォルト値を設定
+    self.lastNumberOfServings = portionSize
 
-    // 栄養素に基づく一意キーを生成
-    let caloriesStr = String(format: "%.2f", calories)
-    let sugarStr = String(format: "%.2f", sugar)
-    let fiberStr = String(format: "%.2f", dietaryFiber)
-    let fatStr = String(format: "%.2f", fat)
-    let proteinStr = String(format: "%.2f", protein)
-    self.uniqueKey =
-      "\(brandName)|\(productName)|\(caloriesStr)|\(sugarStr)|\(fiberStr)|\(fatStr)|\(proteinStr)|\(portionUnit)"
+    self.uniqueKey = FoodMaster.createUniqueKey(
+      brandName: brandName, productName: productName, portionUnit: portionUnit)
   }
 
-  // 使用頻度とサービング数を更新するメソッド
+  /// uniqueKeyを生成する静的メソッド（CSVImporterと共用）
+  static func createUniqueKey(brandName: String, productName: String, portionUnit: String) -> String
+  {
+    "\(brandName)|\(productName)|\(portionUnit)"
+  }
+}
+
+// MARK: - 使用統計
+extension FoodMaster {
+  /// 使用頻度とサービング数を更新するメソッド
   func incrementUsageWithServings(_ servings: Double) {
     self.usageCount += 1
     self.lastUsedDate = Date()
     self.lastNumberOfServings = servings
   }
 
-  // 使用頻度をデクリメントするメソッド
+  /// 使用頻度をデクリメントするメソッド
   func decrementUsage() {
     if self.usageCount > 0 {
       self.usageCount -= 1
     }
-    // 最終使用日は更新しない（最後に使われた日時は変わらない）
   }
 }

--- a/BiteLog/Models/NutritionSnapshot.swift
+++ b/BiteLog/Models/NutritionSnapshot.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// FoodMasterの栄養素情報のスナップショット（LogItemのバックアップ用）
+/// 栄養素値はportionSize分の量に対する値（CSVの元データそのまま）
+struct NutritionSnapshot: Codable, Equatable {
+  var brandName: String
+  var productName: String
+  var calories: Double
+  var netCarbs: Double
+  var dietaryFiber: Double
+  var fat: Double
+  var protein: Double
+  var portionSize: Double
+  var portionUnit: String
+
+  var carbs: Double { netCarbs + dietaryFiber }
+
+  /// 指定量に対する栄養素値を計算
+  /// - Parameter amount: 実際の摂取量（例: 50g）
+  /// - Returns: amount分の栄養素値
+  func scaled(by amount: Double) -> NutritionValues {
+    let ratio = portionSize > 0 ? amount / portionSize : 0
+    return NutritionValues(
+      calories: calories * ratio,
+      netCarbs: netCarbs * ratio,
+      dietaryFiber: dietaryFiber * ratio,
+      fat: fat * ratio,
+      protein: protein * ratio
+    )
+  }
+
+  /// FoodMasterからスナップショットを作成
+  static func from(_ foodMaster: FoodMaster) -> NutritionSnapshot {
+    NutritionSnapshot(
+      brandName: foodMaster.brandName,
+      productName: foodMaster.productName,
+      calories: foodMaster.calories,
+      netCarbs: foodMaster.netCarbs,
+      dietaryFiber: foodMaster.dietaryFiber,
+      fat: foodMaster.fat,
+      protein: foodMaster.protein,
+      portionSize: foodMaster.portionSize,
+      portionUnit: foodMaster.portionUnit
+    )
+  }
+}
+
+/// 計算済みの栄養素値（実際の摂取量に対する値）
+struct NutritionValues {
+  let calories: Double
+  let netCarbs: Double
+  let dietaryFiber: Double
+  let fat: Double
+  let protein: Double
+
+  var carbs: Double { netCarbs + dietaryFiber }
+
+  static let zero = NutritionValues(
+    calories: 0, netCarbs: 0, dietaryFiber: 0, fat: 0, protein: 0)
+
+  static func + (lhs: NutritionValues, rhs: NutritionValues) -> NutritionValues {
+    NutritionValues(
+      calories: lhs.calories + rhs.calories,
+      netCarbs: lhs.netCarbs + rhs.netCarbs,
+      dietaryFiber: lhs.dietaryFiber + rhs.dietaryFiber,
+      fat: lhs.fat + rhs.fat,
+      protein: lhs.protein + rhs.protein
+    )
+  }
+}

--- a/BiteLog/Utilities/AIFoodAnalyzer.swift
+++ b/BiteLog/Utilities/AIFoodAnalyzer.swift
@@ -20,9 +20,9 @@ struct FoodAnalysisResult {
   let calories: Double
   let protein: Double
   let fat: Double
-  let sugar: Double
+  let netCarbs: Double
   let dietaryFiber: Double
-  let portion: Double
+  let portionAmount: Double
   let portionUnit: String
   let confidence: String
 }
@@ -167,9 +167,9 @@ class AIFoodAnalyzer {
       calories: json["calories"] as? Double ?? 0,
       protein: json["protein"] as? Double ?? 0,
       fat: json["fat"] as? Double ?? 0,
-      sugar: json["sugar"] as? Double ?? 0,
+      netCarbs: json["sugar"] as? Double ?? 0,
       dietaryFiber: json["dietaryFiber"] as? Double ?? 0,
-      portion: json["portion"] as? Double ?? 1,
+      portionAmount: json["portion"] as? Double ?? 1,
       portionUnit: json["portionUnit"] as? String ?? "人前",
       confidence: json["confidence"] as? String ?? "medium"
     )

--- a/BiteLog/Utilities/CSVExporter.swift
+++ b/BiteLog/Utilities/CSVExporter.swift
@@ -1,11 +1,11 @@
 import Foundation
-import SwiftData
 import OSLog
+import SwiftData
 
 enum CSVExportError: Error {
   case dataWriteFailed
   case fileCreationFailed
-  
+
   var localizedDescription: String {
     switch self {
     case .dataWriteFailed:
@@ -20,36 +20,38 @@ class CSVExporter {
   // ロガーの設定
   private static let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.bitelog", category: "CSVExporter")
-  
+
   // 進捗状況を報告するためのコールバック
-  typealias ProgressHandler = (Double, Int, Int) -> Bool  // 進捗率, 現在の行, 全行数, キャンセルならtrue
-  
+  typealias ProgressHandler = (Double, Int, Int) -> Bool
+
   // CSVラインをエスケープするヘルパーメソッド
   private static func escapeCSV(_ value: String) -> String {
     var result = value
-    // 数値や日付に変換できない場合はエスケープ処理が必要
     if result.contains("\"") || result.contains(",") || result.contains("\n") {
       result = result.replacingOccurrences(of: "\"", with: "\"\"")
       result = "\"\(result)\""
     }
     return result
   }
-  
+
   // LogItemをCSVファイルにエクスポート
-  static func exportLogItems(to url: URL, context: ModelContext, progressHandler: ProgressHandler? = nil) throws -> Int {
+  static func exportLogItems(
+    to url: URL, context: ModelContext, progressHandler: ProgressHandler? = nil
+  ) throws -> Int {
     let startTime = Date()
     logger.info("LogItemのCSVエクスポート開始")
-    
+
     // すべてのLogItemを取得
-    let fetchDescriptor = FetchDescriptor<LogItem>(sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
+    let fetchDescriptor = FetchDescriptor<LogItem>(
+      sortBy: [SortDescriptor(\.timestamp, order: .reverse)])
     guard let logItems = try? context.fetch(fetchDescriptor) else {
       logger.error("LogItemの取得に失敗しました")
       throw CSVExportError.dataWriteFailed
     }
-    
+
     let totalItems = logItems.count
     logger.info("エクスポート対象: LogItem \(totalItems)件")
-    
+
     // 進捗状況の初期報告
     if let progressHandler = progressHandler {
       if progressHandler(0.0, 0, totalItems) {
@@ -57,42 +59,45 @@ class CSVExporter {
         return 0
       }
     }
-    
+
     // CSVヘッダー
-    let header = "date,meal_type,brand_name,product_name,calories,carbs,dietary_fiber,fat,protein,portion_amount,portion_unit"
+    let header =
+      "date,meal_type,brand_name,product_name,calories,carbs,dietary_fiber,fat,protein,portion_amount,portion_unit"
     var csvString = header + "\n"
-    
+
     // 日付フォーマッタ
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd"
-    
+
     // LogItemをCSV形式に変換
     for (index, item) in logItems.enumerated() {
       // 進捗状況の報告（10アイテムごと）
       if let progressHandler = progressHandler, index % 10 == 0 || index == totalItems - 1 {
         let progress = Double(index + 1) / Double(totalItems)
         if progressHandler(progress, index + 1, totalItems) {
-          logger.notice("ユーザーによりエクスポートがキャンセルされました (\(index + 1)/\(totalItems)件処理後)")
+          logger.notice(
+            "ユーザーによりエクスポートがキャンセルされました (\(index + 1)/\(totalItems)件処理後)")
           return index + 1
         }
       }
-      
+
       let dateString = dateFormatter.string(from: item.timestamp)
       let mealTypeString = item.mealType.rawValue
-      
+
       let brandName = escapeCSV(item.brandName)
       let productName = escapeCSV(item.productName)
-      
+
       // 炭水化物 = 糖質 + 食物繊維
-      let carbs = item.sugar + item.dietaryFiber
-      
+      let carbs = item.netCarbs + item.dietaryFiber
+
       // portion_amountとしてnumberOfServingsを使用
       let portionAmount = item.numberOfServings
-      
-      let row = "\(dateString),\(mealTypeString),\(brandName),\(productName),\(item.calories),\(carbs),\(item.dietaryFiber),\(item.fat),\(item.protein),\(portionAmount),\(escapeCSV(item.portionUnit))"
+
+      let row =
+        "\(dateString),\(mealTypeString),\(brandName),\(productName),\(item.calories),\(carbs),\(item.dietaryFiber),\(item.fat),\(item.protein),\(portionAmount),\(escapeCSV(item.portionUnit))"
       csvString += row + "\n"
     }
-    
+
     // CSVファイルに書き込み
     do {
       try csvString.write(to: url, atomically: true, encoding: .utf8)
@@ -100,10 +105,11 @@ class CSVExporter {
       logger.error("CSVファイルへの書き込みに失敗しました: \(error.localizedDescription)")
       throw CSVExportError.dataWriteFailed
     }
-    
+
     let elapsedTime = Date().timeIntervalSince(startTime)
-    logger.info("LogItemのCSVエクスポート完了: \(totalItems)件, 処理時間=\(String(format: "%.2f", elapsedTime))秒")
-    
+    logger.info(
+      "LogItemのCSVエクスポート完了: \(totalItems)件, 処理時間=\(String(format: "%.2f", elapsedTime))秒")
+
     return totalItems
   }
 }

--- a/BiteLog/Utilities/FoodMasterManager.swift
+++ b/BiteLog/Utilities/FoodMasterManager.swift
@@ -4,11 +4,7 @@ import SwiftData
 class FoodMasterManager {
 
   /// FoodMasterを安全に削除するメソッド
-  /// - Parameters:
-  ///   - foodMaster: 削除するFoodMaster
-  ///   - modelContext: SwiftDataのモデルコンテキスト
   static func safeDeleteFoodMaster(foodMaster: FoodMaster, modelContext: ModelContext) {
-    // 削除するFoodMasterを参照しているLogItemを検索
     let foodMasterId = foodMaster.id
     let descriptor = FetchDescriptor<LogItem>(
       predicate: #Predicate<LogItem> { logItem in
@@ -21,42 +17,31 @@ class FoodMasterManager {
     )
 
     do {
-      // 関連するLogItemを取得
       let relatedLogs = try modelContext.fetch(descriptor)
 
-      // 各LogItemのFoodMasterデータをバックアップ
       for log in relatedLogs {
         log.backupFoodMasterData()
-        log.foodMaster = nil  // リレーションシップを切る
+        log.foodMaster = nil
         log.isMasterDeleted = true
       }
 
-      // FoodMasterを削除
       modelContext.delete(foodMaster)
-
-      // 変更を保存
       try modelContext.save()
-
     } catch {
       print("Error during safe delete: \(error)")
     }
   }
 
   /// 削除されたFoodMasterの情報を表示するための文字列を生成
-  /// - Parameter logItem: 対象のLogItem
-  /// - Returns: 表示用の文字列
   static func getDeletedFoodMasterDisplayText(logItem: LogItem) -> String {
     if logItem.isMasterDeleted {
-      return "\(logItem.backupBrandName ?? "") \(logItem.backupProductName ?? "") (削除済み)"
+      return "\(logItem.brandName) \(logItem.productName) (削除済み)"
     } else {
       return "\(logItem.brandName) \(logItem.productName)"
     }
   }
 
   /// FoodMasterの使用頻度をデクリメントするメソッド
-  /// - Parameters:
-  ///   - foodMaster: 更新するFoodMaster
-  ///   - modelContext: SwiftDataのモデルコンテキスト
   static func decrementUsageCount(foodMaster: FoodMaster, modelContext: ModelContext) {
     foodMaster.decrementUsage()
 
@@ -68,13 +53,9 @@ class FoodMasterManager {
   }
 
   /// LogItemが削除される際にFoodMasterの使用頻度をデクリメントするメソッド
-  /// - Parameters:
-  ///   - logItem: 削除されるLogItem
-  ///   - modelContext: SwiftDataのモデルコンテキスト
   static func decrementUsageCountForLogItemDeletion(logItem: LogItem, modelContext: ModelContext) {
     if let foodMaster = logItem.foodMaster {
       decrementUsageCount(foodMaster: foodMaster, modelContext: modelContext)
     }
   }
-
 }

--- a/BiteLog/Utilities/NutritionGoalsManager.swift
+++ b/BiteLog/Utilities/NutritionGoalsManager.swift
@@ -1,47 +1,120 @@
 import Foundation
+import SwiftData
 import SwiftUI
 
-class NutritionGoalsManager: ObservableObject {
-  // デフォルト値
-  static let defaultProtein: Double = 150
-  static let defaultFat: Double = 80
-  static let defaultSugar: Double = 250
-  static let defaultFiber: Double = 25
-
-  @AppStorage("targetProtein") var targetProtein: Double = defaultProtein {
-    didSet {
-      objectWillChange.send()
-    }
-  }
-
-  @AppStorage("targetFat") var targetFat: Double = defaultFat {
-    didSet {
-      objectWillChange.send()
-    }
-  }
-
-  @AppStorage("targetSugar") var targetSugar: Double = defaultSugar {
-    didSet {
-      objectWillChange.send()
-    }
-  }
-
-  @AppStorage("targetFiber") var targetFiber: Double = defaultFiber {
-    didSet {
-      objectWillChange.send()
-    }
-  }
+@Model
+final class NutritionGoals {
+  @Attribute(.unique) var id: String = "default"
+  var targetProtein: Double = 150
+  var targetFat: Double = 80
+  var targetNetCarbs: Double = 250
+  var targetFiber: Double = 25
 
   /// カロリーは自動計算（タンパク質×4 + 脂質×9 + 糖質×4 + 食物繊維×2）
   var targetCalories: Double {
-    targetProtein * 4 + targetFat * 9 + targetSugar * 4 + targetFiber * 2
+    targetProtein * 4 + targetFat * 9 + targetNetCarbs * 4 + targetFiber * 2
   }
+
+  init() {}
 
   /// デフォルト値にリセット
   func resetToDefaults() {
-    targetProtein = Self.defaultProtein
-    targetFat = Self.defaultFat
-    targetSugar = Self.defaultSugar
-    targetFiber = Self.defaultFiber
+    targetProtein = 150
+    targetFat = 80
+    targetNetCarbs = 250
+    targetFiber = 25
+  }
+}
+
+/// NutritionGoalsのObservableObjectラッパー（View間の共有用）
+class NutritionGoalsManager: ObservableObject {
+  private let modelContext: ModelContext
+
+  @Published private(set) var goals: NutritionGoals
+
+  var targetProtein: Double {
+    get { goals.targetProtein }
+    set {
+      goals.targetProtein = newValue
+      objectWillChange.send()
+      save()
+    }
+  }
+
+  var targetFat: Double {
+    get { goals.targetFat }
+    set {
+      goals.targetFat = newValue
+      objectWillChange.send()
+      save()
+    }
+  }
+
+  var targetNetCarbs: Double {
+    get { goals.targetNetCarbs }
+    set {
+      goals.targetNetCarbs = newValue
+      objectWillChange.send()
+      save()
+    }
+  }
+
+  var targetFiber: Double {
+    get { goals.targetFiber }
+    set {
+      goals.targetFiber = newValue
+      objectWillChange.send()
+      save()
+    }
+  }
+
+  var targetCalories: Double {
+    goals.targetCalories
+  }
+
+  init(modelContext: ModelContext) {
+    self.modelContext = modelContext
+
+    // 既存のNutritionGoalsを取得、なければ作成
+    let descriptor = FetchDescriptor<NutritionGoals>()
+    if let existing = try? modelContext.fetch(descriptor).first {
+      self.goals = existing
+    } else {
+      let newGoals = NutritionGoals()
+      modelContext.insert(newGoals)
+      try? modelContext.save()
+      self.goals = newGoals
+
+      // AppStorageからの移行
+      migrateFromAppStorage()
+    }
+  }
+
+  func resetToDefaults() {
+    goals.resetToDefaults()
+    objectWillChange.send()
+    save()
+  }
+
+  private func save() {
+    try? modelContext.save()
+  }
+
+  /// AppStorageからの移行（初回のみ）
+  private func migrateFromAppStorage() {
+    let defaults = UserDefaults.standard
+    if defaults.object(forKey: "targetProtein") != nil {
+      goals.targetProtein = defaults.double(forKey: "targetProtein")
+      goals.targetFat = defaults.double(forKey: "targetFat")
+      goals.targetNetCarbs = defaults.double(forKey: "targetSugar")
+      goals.targetFiber = defaults.double(forKey: "targetFiber")
+      save()
+
+      // 移行後にAppStorageのキーを削除
+      defaults.removeObject(forKey: "targetProtein")
+      defaults.removeObject(forKey: "targetFat")
+      defaults.removeObject(forKey: "targetSugar")
+      defaults.removeObject(forKey: "targetFiber")
+    }
   }
 }

--- a/BiteLog/Views/AddItemView.swift
+++ b/BiteLog/Views/AddItemView.swift
@@ -619,6 +619,11 @@ struct PastItemCard: View {
     return item.lastNumberOfServings
   }
 
+  /// サービング数に対する栄養素値（portionSizeベースのratio計算）
+  private var nutrition: NutritionValues {
+    NutritionSnapshot.from(item).scaled(by: servings)
+  }
+
   init(item: FoodMaster) {
     self.item = item
   }
@@ -634,7 +639,7 @@ struct PastItemCard: View {
         Spacer()
 
         // カロリーを固定のサービング数に応じて計算
-        Text("\(item.calories * servings, specifier: "%.0f")")
+        Text("\(nutrition.calories, specifier: "%.0f")")
           .font(.title3.bold())
           + Text(" kcal")
           .font(.subheadline)
@@ -643,10 +648,10 @@ struct PastItemCard: View {
 
       HStack(spacing: 8) {
         // 栄養素の値も固定のサービング数に応じて計算
-        MacroNutrientBadge(label: "P", value: item.protein * servings, color: .blue)
-        MacroNutrientBadge(label: "F", value: item.fat * servings, color: .yellow)
-        MacroNutrientBadge(label: "S", value: item.sugar * servings, color: .green)
-        MacroNutrientBadge(label: "Fiber", value: item.dietaryFiber * servings, color: .brown)
+        MacroNutrientBadge(label: "P", value: nutrition.protein, color: .blue)
+        MacroNutrientBadge(label: "F", value: nutrition.fat, color: .yellow)
+        MacroNutrientBadge(label: "S", value: nutrition.netCarbs, color: .green)
+        MacroNutrientBadge(label: "Fiber", value: nutrition.dietaryFiber, color: .brown)
       }
       
       // 分量の表示を追加

--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -196,7 +196,7 @@ struct ItemRowView: View {
       HStack(spacing: 6) {
         MacroChip(label: "P", value: item.protein, color: .blue)
         MacroChip(label: "F", value: item.fat, color: .yellow)
-        MacroChip(label: "S", value: item.sugar, color: .green)
+        MacroChip(label: "S", value: item.netCarbs, color: .green)
         MacroChip(label: "Fb", value: item.dietaryFiber, color: .brown)
 
         Spacer()
@@ -219,7 +219,7 @@ struct ItemRowView: View {
 
 #Preview {
   ContentView()
-    .modelContainer(for: [FoodMaster.self, LogItem.self], inMemory: true)
+    .modelContainer(for: [FoodMaster.self, LogItem.self, NutritionGoals.self], inMemory: true)
 }
 
 // 栄養素行のコンポーネント

--- a/BiteLog/Views/NutritionGoalsEditView.swift
+++ b/BiteLog/Views/NutritionGoalsEditView.swift
@@ -6,7 +6,7 @@ struct NutritionGoalsEditView: View {
 
   @State private var proteinText: String = ""
   @State private var fatText: String = ""
-  @State private var sugarText: String = ""
+  @State private var netCarbsText: String = ""
   @State private var fiberText: String = ""
 
   var body: some View {
@@ -44,7 +44,7 @@ struct NutritionGoalsEditView: View {
 
         nutrientInputRow(
           label: NSLocalizedString("Sugar", comment: "Nutrient label"),
-          text: $sugarText,
+          text: $netCarbsText,
           unit: "g"
         )
 
@@ -91,15 +91,15 @@ struct NutritionGoalsEditView: View {
   private var calculatedCalories: Double {
     let protein = Double(proteinText) ?? 0
     let fat = Double(fatText) ?? 0
-    let sugar = Double(sugarText) ?? 0
+    let netCarbs = Double(netCarbsText) ?? 0
     let fiber = Double(fiberText) ?? 0
-    return protein * 4 + fat * 9 + sugar * 4 + fiber * 2
+    return protein * 4 + fat * 9 + netCarbs * 4 + fiber * 2
   }
 
   private func loadCurrentValues() {
     proteinText = formatValue(nutritionGoalsManager.targetProtein)
     fatText = formatValue(nutritionGoalsManager.targetFat)
-    sugarText = formatValue(nutritionGoalsManager.targetSugar)
+    netCarbsText = formatValue(nutritionGoalsManager.targetNetCarbs)
     fiberText = formatValue(nutritionGoalsManager.targetFiber)
   }
 
@@ -110,8 +110,8 @@ struct NutritionGoalsEditView: View {
     if let fat = Double(fatText), fat > 0 {
       nutritionGoalsManager.targetFat = fat
     }
-    if let sugar = Double(sugarText), sugar > 0 {
-      nutritionGoalsManager.targetSugar = sugar
+    if let netCarbs = Double(netCarbsText), netCarbs > 0 {
+      nutritionGoalsManager.targetNetCarbs = netCarbs
     }
     if let fiber = Double(fiberText), fiber > 0 {
       nutritionGoalsManager.targetFiber = fiber

--- a/BiteLog/Views/PhotoPickerView.swift
+++ b/BiteLog/Views/PhotoPickerView.swift
@@ -184,26 +184,26 @@ struct AIAnalysisResultView: View {
   @State private var calories: String
   @State private var protein: String
   @State private var fat: String
-  @State private var sugar: String
+  @State private var netCarbs: String
   @State private var dietaryFiber: String
-  @State private var portion: String
+  @State private var portionAmount: String
   @State private var portionUnit: String
-  
+
   init(result: FoodAnalysisResult, image: UIImage, mealType: MealType, date: Date, onSave: @escaping () -> Void) {
     self.result = result
     self.image = image
     self.mealType = mealType
     self.date = date
     self.onSave = onSave
-    
+
     // 初期値を設定
     _productName = State(initialValue: result.productName)
     _calories = State(initialValue: String(format: "%.0f", result.calories))
     _protein = State(initialValue: NutritionFormatter.formatNutrition(result.protein))
     _fat = State(initialValue: NutritionFormatter.formatNutrition(result.fat))
-    _sugar = State(initialValue: NutritionFormatter.formatNutrition(result.sugar))
+    _netCarbs = State(initialValue: NutritionFormatter.formatNutrition(result.netCarbs))
     _dietaryFiber = State(initialValue: NutritionFormatter.formatNutrition(result.dietaryFiber))
-    _portion = State(initialValue: NutritionFormatter.formatNutrition(result.portion))
+    _portionAmount = State(initialValue: NutritionFormatter.formatNutrition(result.portionAmount))
     _portionUnit = State(initialValue: result.portionUnit)
   }
   
@@ -237,7 +237,7 @@ struct AIAnalysisResultView: View {
               EditableField(icon: "flame.fill", label: NSLocalizedString("Calories", comment: "Label"), text: $calories, unit: "kcal", keyboardType: .decimalPad, color: .orange)
               
               HStack(spacing: 12) {
-                EditableField(icon: "scalemass.fill", label: NSLocalizedString("Portion", comment: "Label"), text: $portion, keyboardType: .decimalPad)
+                EditableField(icon: "scalemass.fill", label: NSLocalizedString("Portion", comment: "Label"), text: $portionAmount, keyboardType: .decimalPad)
                 EditableField(icon: "tag", label: NSLocalizedString("Unit", comment: "Label"), text: $portionUnit, keyboardType: .default)
               }
             }
@@ -252,11 +252,11 @@ struct AIAnalysisResultView: View {
               
               EditableField(icon: "circle.fill", label: NSLocalizedString("Protein", comment: "Label"), text: $protein, unit: "g", keyboardType: .decimalPad, color: .blue)
               EditableField(icon: "circle.fill", label: NSLocalizedString("Fat", comment: "Label"), text: $fat, unit: "g", keyboardType: .decimalPad, color: .yellow)
-              EditableField(icon: "circle.fill", label: NSLocalizedString("Sugar", comment: "Label"), text: $sugar, unit: "g", keyboardType: .decimalPad, color: .green)
+              EditableField(icon: "circle.fill", label: NSLocalizedString("Sugar", comment: "Label"), text: $netCarbs, unit: "g", keyboardType: .decimalPad, color: .green)
               EditableField(icon: "circle.fill", label: NSLocalizedString("Dietary Fiber", comment: "Label"), text: $dietaryFiber, unit: "g", keyboardType: .decimalPad, color: .brown)
               
               // 炭水化物は計算値として表示（編集不可）
-              let carbs = (Double(sugar) ?? 0) + (Double(dietaryFiber) ?? 0)
+              let carbs = (Double(netCarbs) ?? 0) + (Double(dietaryFiber) ?? 0)
               ResultRow(icon: "circle.fill", label: NSLocalizedString("Carbohydrates", comment: "Label"), value: "\(NutritionFormatter.formatNutrition(carbs))g", color: .purple)
             }
             .padding()
@@ -352,21 +352,21 @@ struct AIAnalysisResultView: View {
     let caloriesValue = Double(calories) ?? 0
     let proteinValue = Double(protein) ?? 0
     let fatValue = Double(fat) ?? 0
-    let sugarValue = Double(sugar) ?? 0
+    let netCarbsValue = Double(netCarbs) ?? 0
     let dietaryFiberValue = Double(dietaryFiber) ?? 0
-    let portionValue = Double(portion) ?? 1
-    
+    let portionAmountValue = Double(portionAmount) ?? 1
+
     // FoodMasterを作成
     let foodMaster = FoodMaster(
       brandName: "AI",
       productName: productName,
       calories: caloriesValue,
-      sugar: sugarValue,
+      netCarbs: netCarbsValue,
       dietaryFiber: dietaryFiberValue,
       fat: fatValue,
       protein: proteinValue,
-      portionUnit: portionUnit,
-      portion: portionValue
+      portionSize: portionAmountValue,
+      portionUnit: portionUnit
     )
     modelContext.insert(foodMaster)
     
@@ -374,7 +374,7 @@ struct AIAnalysisResultView: View {
     let logItem = LogItem(
       timestamp: date,
       mealType: mealType,
-      numberOfServings: 1.0,
+      numberOfServings: portionAmountValue,
       foodMaster: foodMaster
     )
     modelContext.insert(logItem)


### PR DESCRIPTION
## Summary
- **NutritionSnapshot値型の導入**: LogItemのバックアップフィールドを10個のOptionalから`nutritionSnapshotData: Data?`（JSON）1フィールドに統合
- **portionSizeの導入**: CSVインポート時の1単位あたり正規化（除算）を廃止し、CSVの栄養素値をそのまま保存。ratio計算（`栄養素 × 摂取量 / portionSize`）で精度を維持
- **sugar → netCarbsリネーム**: モデル全体で栄養学的に正確な命名に変更
- **uniqueKey簡素化**: `brandName|productName|portionUnit` のみ（栄養素値を除外）
- **logDate追加**: `yyyy-MM-dd`文字列による日付フィルタリングの簡素化
- **NutritionGoalsのSwiftData化**: AppStorageからSwiftData @Modelに移行
- **FoodMasterの使用統計をextension分離**: ドメインの関心を整理

## Test plan
- [ ] CSVインポート→エクスポートのラウンドトリップテスト（データ損失がないか）
- [ ] FoodMaster削除後のLogItem表示が正常か確認
- [ ] 日付フィルタリングの動作確認
- [ ] FoodMasterフォームでportionSize入力が正しく保存されるか確認
- [ ] EditItemViewで栄養素のratio計算が正しいか確認（例: 100g/210kcalの食品を50g → 105kcal）
- [ ] AI分析結果の保存でportionSizeが正しく設定されるか確認
- [ ] NutritionGoalsの値がAppStorageからSwiftDataに正しく移行されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)