### PR TITLE
security: OpenAI APIキーをクライアントから排除しWorker経由プロキシに移行

### DIFF
--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -204,6 +204,12 @@ final class APIClient {
     return try await request(path: "/api/nutrition-goals", method: "PUT", body: dto)
   }
 
+  // MARK: - AI
+
+  func analyzeFoodImage(imageBase64: String) async throws -> AIAnalyzeResponse {
+    return try await request(path: "/api/ai/analyze-food", method: "POST", body: AIAnalyzeRequest(imageBase64: imageBase64))
+  }
+
   // MARK: - Auth
 
   func signIn(provider: String, identityToken: String) async throws -> AuthResponse {

--- a/BiteLog/Network/DTOs.swift
+++ b/BiteLog/Network/DTOs.swift
@@ -171,3 +171,21 @@ extension NutritionSnapshot {
     )
   }
 }
+
+// MARK: - AI Analyze DTO
+
+struct AIAnalyzeRequest: Codable {
+  var imageBase64: String
+}
+
+struct AIAnalyzeResponse: Codable {
+  var calories: Double
+  var protein: Double
+  var fat: Double
+  var netCarbs: Double
+  var dietaryFiber: Double
+  var portionAmount: Double
+  var portionUnit: String
+  var confidence: String
+  var productName: String
+}

--- a/BiteLog/Utilities/AIFoodAnalyzer.swift
+++ b/BiteLog/Utilities/AIFoodAnalyzer.swift
@@ -1,19 +1,6 @@
 import Foundation
 import UIKit
 
-// OpenAI APIのレスポンス構造体
-struct OpenAIResponse: Codable {
-  let choices: [Choice]
-  
-  struct Choice: Codable {
-    let message: Message
-  }
-  
-  struct Message: Codable {
-    let content: String
-  }
-}
-
 // 分析結果の構造体
 struct FoodAnalysisResult {
   let productName: String
@@ -29,239 +16,86 @@ struct FoodAnalysisResult {
 
 class AIFoodAnalyzer {
   static let shared = AIFoodAnalyzer()
-  
+
   private init() {}
-  
-  // APIキーを取得
-  private var apiKey: String {
-    return APIKeys.openAI
+
+  @MainActor
+  func isAvailable() -> Bool {
+    return AuthManager.shared.isSignedIn
   }
-  
-  // APIキーが設定されているか確認
-  func isAPIKeyConfigured() -> Bool {
-    // プレースホルダーでないかチェック
-    let key = apiKey
-    return !key.isEmpty && 
-           key != "YOUR_OPENAI_API_KEY_HERE" && 
-           key != "あなたのAPIキーをここに入力してください"
-  }
-  
+
   // 写真から料理を分析
   func analyzeFood(image: UIImage) async throws -> FoodAnalysisResult {
-    guard isAPIKeyConfigured() else {
-      throw AnalysisError.apiKeyNotConfigured
+    let available = await MainActor.run { AuthManager.shared.isSignedIn }
+    guard available else {
+      throw AnalysisError.notAuthenticated
     }
-    
-    let apiKey = self.apiKey
-    
+
     // 画像をリサイズしてBase64に変換
     guard let resizedImage = resizeImage(image, maxSize: 1024),
           let imageData = resizedImage.jpegData(compressionQuality: 0.8) else {
       throw AnalysisError.imageProcessingFailed
     }
-    
+
     let base64Image = imageData.base64EncodedString()
-    
-    // OpenAI APIリクエストを構築
-    let url = URL(string: "https://api.openai.com/v1/chat/completions")!
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    
-    // プロンプトを構築
-    let prompt = """
-    Analyze this image and return nutrition information in JSON format.
-    
-    IMPORTANT - Nutrition Label Reading:
-    If the image contains a nutrition facts label (package/product label), prioritize reading the text:
-    - Calories/Energy/カロリー/熱量
-    - Protein/たんぱく質/タンパク質
-    - Fat/脂質
-    - Sugar/Carbohydrate/糖質
-    - Dietary Fiber/食物繊維
-    - Total Carbohydrates/炭水化物
-    If "糖質" and "食物繊維" are both listed, use those values directly. If only "炭水化物" is listed, set sugar = 炭水化物 and dietaryFiber = 0.
-    If a nutrition label is present, set confidence to "high".
-    
-    Return ONLY this JSON format (no other text):
-    {
-      "productName": "Product or dish name in Japanese",
-      "calories": number in kcal,
-      "protein": number in grams,
-      "fat": number in grams,
-      "sugar": number in grams,
-      "dietaryFiber": number in grams,
-      "portion": portion amount (number),
-      "portionUnit": "unit (e.g., g, ml, 個, 人前)",
-      "confidence": "high" or "medium" or "low"
+
+    do {
+      let response = try await APIClient.shared.analyzeFoodImage(imageBase64: base64Image)
+      return FoodAnalysisResult(
+        productName: response.productName,
+        calories: response.calories,
+        protein: response.protein,
+        fat: response.fat,
+        netCarbs: response.netCarbs,
+        dietaryFiber: response.dietaryFiber,
+        portionAmount: response.portionAmount,
+        portionUnit: response.portionUnit,
+        confidence: response.confidence
+      )
+    } catch APIError.unauthorized {
+      throw AnalysisError.notAuthenticated
+    } catch APIError.serverError(429) {
+      throw AnalysisError.rateLimitExceeded
+    } catch {
+      throw error
     }
-    
-    Rules:
-    - If nutrition label exists, read and use those exact values
-    - For food photos without labels, estimate typical serving size
-    - For multiple items, sum the total values
-    - Return JSON only, no explanations
-    """
-    
-    let requestBody: [String: Any] = [
-      "model": "gpt-5-mini",
-      "messages": [
-        [
-          "role": "user",
-          "content": [
-            [
-              "type": "text",
-              "text": prompt
-            ],
-            [
-              "type": "image_url",
-              "image_url": [
-                "url": "data:image/jpeg;base64,\(base64Image)"
-              ]
-            ]
-          ]
-        ]
-      ],
-      "max_completion_tokens": 4096
-    ]
-    
-    request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
-    
-    // APIリクエストを送信
-    let (data, response) = try await URLSession.shared.data(for: request)
-    
-    // レスポンスを確認
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw AnalysisError.invalidResponse
-    }
-    
-    guard httpResponse.statusCode == 200 else {
-      if httpResponse.statusCode == 401 {
-        throw AnalysisError.invalidAPIKey
-      } else if httpResponse.statusCode == 429 {
-        throw AnalysisError.rateLimitExceeded
-      }
-      throw AnalysisError.apiError(statusCode: httpResponse.statusCode)
-    }
-    
-    // レスポンスをデコード
-    let openAIResponse = try JSONDecoder().decode(OpenAIResponse.self, from: data)
-    
-    guard let content = openAIResponse.choices.first?.message.content else {
-      throw AnalysisError.noContent
-    }
-    
-    // JSON部分を抽出（```json```で囲まれている場合もあるため）
-    let jsonString = extractJSON(from: content)
-    
-    // JSONをパース
-    guard let jsonData = jsonString.data(using: .utf8),
-          let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-      throw AnalysisError.invalidJSONResponse
-    }
-    
-    // 結果を構築
-    let result = FoodAnalysisResult(
-      productName: json["productName"] as? String ?? "不明な料理",
-      calories: json["calories"] as? Double ?? 0,
-      protein: json["protein"] as? Double ?? 0,
-      fat: json["fat"] as? Double ?? 0,
-      netCarbs: json["sugar"] as? Double ?? 0,
-      dietaryFiber: json["dietaryFiber"] as? Double ?? 0,
-      portionAmount: json["portion"] as? Double ?? 1,
-      portionUnit: json["portionUnit"] as? String ?? "人前",
-      confidence: json["confidence"] as? String ?? "medium"
-    )
-    
-    return result
   }
-  
+
   // 画像をリサイズ
   private func resizeImage(_ image: UIImage, maxSize: CGFloat) -> UIImage? {
     let size = image.size
     let ratio = min(maxSize / size.width, maxSize / size.height)
-    
+
     if ratio >= 1 {
       return image
     }
-    
+
     let newSize = CGSize(width: size.width * ratio, height: size.height * ratio)
     let renderer = UIGraphicsImageRenderer(size: newSize)
-    
+
     return renderer.image { _ in
       image.draw(in: CGRect(origin: .zero, size: newSize))
     }
   }
-  
-  // JSON部分を抽出
-  private func extractJSON(from text: String) -> String {
-    // ```json と ``` で囲まれている場合
-    if let jsonStart = text.range(of: "```json"),
-       let jsonEnd = text.range(of: "```", range: jsonStart.upperBound..<text.endIndex) {
-      return String(text[jsonStart.upperBound..<jsonEnd.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    
-    // { と } で囲まれた部分を抽出（ネスト対応）
-    if let jsonStart = text.firstIndex(of: "{") {
-      var braceCount = 0
-      var jsonEnd: String.Index?
-      var isInString = false
-      var previousChar: Character?
-      
-      for index in text[jsonStart...].indices {
-        let char = text[index]
-        
-        // 文字列リテラル内かどうかを判定（エスケープされた引用符を考慮）
-        if char == "\"" && previousChar != "\\" {
-          isInString.toggle()
-        }
-        
-        // 文字列リテラル内でない場合のみブレースをカウント
-        if !isInString {
-          if char == "{" {
-            braceCount += 1
-          } else if char == "}" {
-            braceCount -= 1
-            if braceCount == 0 {
-              jsonEnd = index
-              break
-            }
-          }
-        }
-        
-        previousChar = char
-      }
-      
-      if let end = jsonEnd {
-        return String(text[jsonStart...end])
-      }
-    }
-    
-    return text.trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-  
+
   // エラー定義
   enum AnalysisError: LocalizedError {
-    case apiKeyNotConfigured
+    case notAuthenticated
     case imageProcessingFailed
     case invalidResponse
-    case invalidAPIKey
     case rateLimitExceeded
     case apiError(statusCode: Int)
     case noContent
     case invalidJSONResponse
-    
+
     var errorDescription: String? {
       switch self {
-      case .apiKeyNotConfigured:
-        return NSLocalizedString("OpenAI API key is not configured. Please set it in Settings.", comment: "Error message")
+      case .notAuthenticated:
+        return NSLocalizedString("AI food analysis requires sign-in.", comment: "Error message")
       case .imageProcessingFailed:
         return NSLocalizedString("Failed to process image.", comment: "Error message")
       case .invalidResponse:
         return NSLocalizedString("Invalid response from API.", comment: "Error message")
-      case .invalidAPIKey:
-        return NSLocalizedString("Invalid API key. Please check your API key in Settings.", comment: "Error message")
       case .rateLimitExceeded:
         return NSLocalizedString("API rate limit exceeded. Please try again later.", comment: "Error message")
       case .apiError(let statusCode):
@@ -274,4 +108,3 @@ class AIFoodAnalyzer {
     }
   }
 }
-

--- a/BiteLog/Views/AddItemView.swift
+++ b/BiteLog/Views/AddItemView.swift
@@ -56,7 +56,7 @@ struct AddItemView: View {
         }
         ToolbarItem(placement: .confirmationAction) {
           Button {
-            if AIFoodAnalyzer.shared.isAPIKeyConfigured() { showingPhotoPicker = true }
+            if AIFoodAnalyzer.shared.isAvailable() { showingPhotoPicker = true }
             else { showingAPIKeyError = true }
           } label: {
             Image(systemName: "camera.viewfinder").font(.title3)
@@ -75,11 +75,10 @@ struct AddItemView: View {
           AIAnalysisResultView(result: result, image: image, mealType: mealType, date: date, onSave: { dismiss() })
         }
       }
-      .alert(NSLocalizedString("API Key Required", comment: "Alert title"), isPresented: $showingAPIKeyError) {
-        Button(NSLocalizedString("Open Settings", comment: "Button title")) { dismiss(); selectedTab = 2 }
-        Button(NSLocalizedString("Cancel", comment: "Button title"), role: .cancel) {}
+      .alert(NSLocalizedString("Sign In Required", comment: "Alert title"), isPresented: $showingAPIKeyError) {
+        Button(NSLocalizedString("OK", comment: "Button title"), role: .cancel) {}
       } message: {
-        Text(NSLocalizedString("Please set your OpenAI API key in Settings to use AI food analysis.", comment: "Alert message"))
+        Text(NSLocalizedString("Please sign in to use AI food analysis.", comment: "Alert message"))
       }
       .alert(NSLocalizedString("Analysis Error", comment: "Alert title"), isPresented: .constant(analysisError != nil)) {
         Button(NSLocalizedString("OK", comment: "Button title"), role: .cancel) { analysisError = nil }

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -7,6 +7,7 @@ import logItems from './routes/logItems';
 import nutritionGoals from './routes/nutritionGoals';
 import userData from './routes/userData';
 import csvImport from './routes/csvImport';
+import aiAnalyze from './routes/aiAnalyze';
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -31,6 +32,7 @@ app.route('/api/log-items', logItems);
 app.route('/api/nutrition-goals', nutritionGoals);
 app.route('/api/user-data', userData);
 app.route('/api/csv', csvImport);
+app.route('/api/ai', aiAnalyze);
 
 // ヘルスチェック
 app.get('/health', (c) => c.json({ ok: true }));

--- a/cloudflare/src/routes/aiAnalyze.ts
+++ b/cloudflare/src/routes/aiAnalyze.ts
@@ -1,0 +1,124 @@
+import { Hono } from 'hono';
+import type { Bindings, Variables } from '../types';
+import { authMiddleware } from '../middleware/auth';
+
+const aiAnalyze = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+aiAnalyze.use('*', authMiddleware);
+
+const PROMPT = `Analyze this image and return nutrition information in JSON format.
+
+IMPORTANT - Nutrition Label Reading:
+If the image contains a nutrition facts label (package/product label), prioritize reading the text:
+- Calories/Energy/カロリー/熱量
+- Protein/たんぱく質/タンパク質
+- Fat/脂質
+- Sugar/Carbohydrate/糖質
+- Dietary Fiber/食物繊維
+- Total Carbohydrates/炭水化物
+If "糖質" and "食物繊維" are both listed, use those values directly. If only "炭水化物" is listed, set sugar = 炭水化物 and dietaryFiber = 0.
+If a nutrition label is present, set confidence to "high".
+
+Return ONLY this JSON format (no other text):
+{
+  "productName": "Product or dish name in Japanese",
+  "calories": number in kcal,
+  "protein": number in grams,
+  "fat": number in grams,
+  "sugar": number in grams,
+  "dietaryFiber": number in grams,
+  "portion": portion amount (number),
+  "portionUnit": "unit (e.g., g, ml, 個, 人前)",
+  "confidence": "high" or "medium" or "low"
+}
+
+Rules:
+- If nutrition label exists, read and use those exact values
+- For food photos without labels, estimate typical serving size
+- For multiple items, sum the total values
+- Return JSON only, no explanations`;
+
+aiAnalyze.post('/analyze-food', async (c) => {
+  const body = await c.req.json<{ imageBase64?: string }>();
+
+  if (!body.imageBase64 || typeof body.imageBase64 !== 'string') {
+    return c.json({ error: 'imageBase64 is required' }, 400);
+  }
+
+  let openaiRes: Response;
+  try {
+    openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${c.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-5-mini',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: PROMPT },
+              {
+                type: 'image_url',
+                image_url: { url: `data:image/jpeg;base64,${body.imageBase64}` },
+              },
+            ],
+          },
+        ],
+        max_completion_tokens: 4096,
+      }),
+    });
+  } catch {
+    return c.json({ error: 'Failed to reach OpenAI API' }, 500);
+  }
+
+  if (!openaiRes.ok) {
+    if (openaiRes.status === 429) return c.json({ error: 'Rate limit exceeded' }, 429);
+    if (openaiRes.status === 401) return c.json({ error: 'AI service configuration error' }, 502);
+    return c.json({ error: 'AI service error' }, 500);
+  }
+
+  const openaiData = await openaiRes.json<{
+    choices: Array<{ message: { content: string } }>;
+  }>();
+
+  const content = openaiData.choices?.[0]?.message?.content;
+  if (!content) {
+    return c.json({ error: 'No content from AI' }, 500);
+  }
+
+  const parsed = extractAndParseJSON(content);
+  if (!parsed) {
+    return c.json({ error: 'Failed to parse AI response' }, 500);
+  }
+
+  return c.json({
+    calories: (parsed['calories'] as number) ?? 0,
+    protein: (parsed['protein'] as number) ?? 0,
+    fat: (parsed['fat'] as number) ?? 0,
+    netCarbs: (parsed['sugar'] as number) ?? 0,
+    dietaryFiber: (parsed['dietaryFiber'] as number) ?? 0,
+    portionAmount: (parsed['portion'] as number) ?? 1,
+    portionUnit: (parsed['portionUnit'] as string) ?? '人前',
+    confidence: (parsed['confidence'] as string) ?? 'medium',
+    productName: (parsed['productName'] as string) ?? '不明な料理',
+  });
+});
+
+function extractAndParseJSON(text: string): Record<string, unknown> | null {
+  const fenceMatch = text.match(/```json\s*([\s\S]*?)```/);
+  const candidate = fenceMatch ? fenceMatch[1].trim() : text.trim();
+
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start === -1 || end === -1) return null;
+
+  try {
+    return JSON.parse(candidate.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export default aiAnalyze;

--- a/cloudflare/src/types.ts
+++ b/cloudflare/src/types.ts
@@ -4,6 +4,7 @@ export type Bindings = {
   ADMIN_API_KEY: string;
   ADMIN_USER_ID: string;
   GOOGLE_CLIENT_ID: string;
+  OPENAI_API_KEY: string;
 };
 
 export type Variables = {


### PR DESCRIPTION
fixes #81

## Summary

- Cloudflare Worker に `/api/ai/analyze-food` プロキシエンドポイントを追加（認証必須）
- OpenAI API キーを `wrangler secret` で管理し、iOS クライアントから完全に排除
- `AIFoodAnalyzer.swift` が直接 OpenAI API を叩く構造を廃止し、既存の `APIClient` 経由に変更
- `APIKeys.swift`（実キー保持ファイル）を削除

## 変更の単位

1. **Worker プロキシ追加** (`cloudflare/`): `aiAnalyze.ts` 新規、`types.ts` / `index.ts` 更新
2. **iOS ネットワーク層** (`Network/`): `AIAnalyzeRequest` / `AIAnalyzeResponse` DTO と `analyzeFoodImage()` 追加
3. **セキュリティ修正** (`AIFoodAnalyzer.swift`, `AddItemView.swift`): APIキー参照の削除・`APIKeys.swift` 削除

## Test plan

- [ ] `wrangler secret put OPENAI_API_KEY` で新しいキーをセット
- [ ] `wrangler deploy` でデプロイ
- [ ] サインアウト状態でカメラアイコンタップ → "サインインが必要です" アラートが表示される
- [ ] サインイン後にカメラアイコンタップ → フォトピッカーが開き、写真選択後に分析結果が表示される
- [ ] ビルドエラーなし（`APIKeys` 参照ゼロを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)