### PR TITLE
remove: Skip Sign Inデバッグ機能の削除

### DIFF
--- a/BiteLog/Views/LoginView.swift
+++ b/BiteLog/Views/LoginView.swift
@@ -46,15 +46,6 @@ struct LoginView: View {
           }
           .frame(height: 50)
 
-          #if DEBUG
-          Button("Debug: Skip Sign In") {
-            // Workers に認証なしでアクセスするためのデバッグ用ダミートークン
-            // Workers側で "debug-bypass" を許可する必要あり
-            debugSignIn()
-          }
-          .font(.footnote)
-          .foregroundColor(.secondary)
-          #endif
         }
 
         if let error = errorMessage {
@@ -71,21 +62,6 @@ struct LoginView: View {
     }
     .padding()
   }
-
-  #if DEBUG
-  private func debugSignIn() {
-    isSigningIn = true
-    Task {
-      do {
-        let response = try await APIClient.shared.signIn(provider: "debug", identityToken: "debug-bypass-token")
-        AuthManager.shared.storeToken(response.token)
-      } catch {
-        errorMessage = "Debug sign in failed: \(error.localizedDescription)"
-      }
-      isSigningIn = false
-    }
-  }
-  #endif
 
   private func handleGoogleSignIn() {
     isSigningIn = true


### PR DESCRIPTION
## Summary
- `LoginView.swift` のデバッグ用「Skip Sign In」ボタンを削除
- 関連する `debugSignIn()` 関数（`#if DEBUG` ブロック）を削除

## 背景
開発中にWorker認証をバイパスするために追加したデバッグ機能。Worker側はすでに `debug` プロバイダーを受け付けない実装（`apple` / `google` 以外は400エラー）になっているため、iOSアプリ側も合わせて削除する。

Closes #83

## Test plan
- [ ] ビルドが通ること
- [ ] LoginViewにSign In With AppleとGoogle Sign Inボタンのみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)