### PR TITLE
fix: AI Food Analysisのログ登録失敗とJWT期限切れ時の自動サインアウト

### DIFF
--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -66,6 +66,7 @@ final class APIClient {
     case 200...299:
       break
     case 401:
+      await AuthManager.shared.signOut()
       throw APIError.unauthorized
     case 404:
       throw APIError.notFound
@@ -107,7 +108,9 @@ final class APIClient {
     guard let http = response as? HTTPURLResponse else { return }
     switch http.statusCode {
     case 200...299: break
-    case 401: throw APIError.unauthorized
+    case 401:
+      await AuthManager.shared.signOut()
+      throw APIError.unauthorized
     case 404: throw APIError.notFound
     default: throw APIError.serverError(http.statusCode)
     }

--- a/BiteLog/Views/PhotoPickerView.swift
+++ b/BiteLog/Views/PhotoPickerView.swift
@@ -177,6 +177,7 @@ struct AIAnalysisResultView: View {
   var onSave: () -> Void
   
   @State private var showingSaveConfirmation = false
+  @State private var saveError: String?
   
   // 編集可能なフィールド
   @State private var productName: String
@@ -305,6 +306,11 @@ struct AIAnalysisResultView: View {
       } message: {
         Text(String(format: NSLocalizedString("Save \"%@\" to %@?", comment: "Alert message"), productName, mealType.localizedName))
       }
+      .alert(NSLocalizedString("Save Failed", comment: "Alert title"), isPresented: Binding(get: { saveError != nil }, set: { if !$0 { saveError = nil } })) {
+        Button(NSLocalizedString("OK", comment: "Button title"), role: .cancel) {}
+      } message: {
+        Text(saveError ?? "")
+      }
     }
   }
   
@@ -382,12 +388,15 @@ struct AIAnalysisResultView: View {
           nutritionSnapshot: NutritionSnapshot.from(fm)
         )
         _ = try await APIClient.shared.createLogItem(logDTO)
+        await MainActor.run {
+          onSave()
+          dismiss()
+        }
       } catch {
         print("AIAnalysisResultView saveFoodItem error: \(error)")
-      }
-      await MainActor.run {
-        onSave()
-        dismiss()
+        await MainActor.run {
+          saveError = NSLocalizedString("Failed to save. Please try again.", comment: "Save error message")
+        }
       }
     }
   }

--- a/cloudflare/src/routes/foodMasters.ts
+++ b/cloudflare/src/routes/foodMasters.ts
@@ -108,8 +108,8 @@ foodMasters.post('/', async (c) => {
   ).run();
 
   const row = await c.env.DB.prepare(
-    `SELECT * FROM food_masters WHERE unique_key = ?`
-  ).bind(body.uniqueKey).first<FoodMasterRow>();
+    `SELECT ${FM_SELECT} ${FM_JOIN} WHERE fm.unique_key = ?`
+  ).bind(userId, body.uniqueKey).first<FoodMasterRow>();
 
   return c.json(foodMasterToResponse(row!), 201);
 });


### PR DESCRIPTION
## Summary

- AI Food Analysisで「Save to Food Log」を押してもログが登録されないバグを修正 (Closes #88)
- JWTトークン期限切れ後も自動サインアウトされず「Sign Out」が表示され続ける問題を修正 (Closes #89)

## 変更内容

### `cloudflare/src/routes/foodMasters.ts`
`POST /api/food-masters` のレスポンス取得クエリを `SELECT *` から `FM_SELECT + FM_JOIN` に変更。`user_food_stats` とのJOINが欠落していたため `usage_count` 等がレスポンスに含まれず、iOS側の `FoodMasterDTO` デコードが失敗していた。

### `BiteLog/Views/PhotoPickerView.swift`
`saveFoodItem()` のエラーハンドリングを改善:
- `onSave()` / `dismiss()` を do ブロック内（成功時のみ）に移動
- catch ブロックでユーザーにエラーアラートを表示

### `BiteLog/Network/APIClient.swift`
`request()` と `requestVoid()` 両メソッドで HTTP 401 受信時に `AuthManager.shared.signOut()` を呼び出し、セッション期限切れを自動検出してサインイン画面へ遷移するよう対応。

## Test plan

- [ ] AI Food Analysisで食品を分析→「Save to Food Log」でログに追加されることを確認
- [ ] 同じ食品名を2回分析した場合（uniqueKey重複）もログが正常に追加されることを確認
- [ ] セッションが期限切れの状態でAPIを呼び出すと自動的にサインイン画面に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)