### PR TITLE
fix: 起動時にJWT期限切れを確認しサインアウト状態に遷移する

### DIFF
--- a/BiteLog/Auth/AuthManager.swift
+++ b/BiteLog/Auth/AuthManager.swift
@@ -18,11 +18,16 @@ final class AuthManager: NSObject, ObservableObject {
 
   override init() {
     super.init()
-    // 起動時にKeychainからトークンを復元
+    // 起動時にKeychainからトークンを復元（期限切れなら削除）
     if let token = loadTokenFromKeychain() {
-      self.isSignedIn = true
-      self.userId = extractUserId(from: token)
-      self.isAdmin = UserDefaults.standard.bool(forKey: isAdminKey)
+      if isTokenExpired(token) {
+        deleteTokenFromKeychain()
+        UserDefaults.standard.removeObject(forKey: isAdminKey)
+      } else {
+        self.isSignedIn = true
+        self.userId = extractUserId(from: token)
+        self.isAdmin = UserDefaults.standard.bool(forKey: isAdminKey)
+      }
     }
   }
 
@@ -162,6 +167,18 @@ final class AuthManager: NSObject, ObservableObject {
   }
 
   private func extractUserId(from token: String) -> String? {
+    guard let payload = decodeJWTPayload(token) else { return nil }
+    return payload["sub"] as? String
+  }
+
+  private func isTokenExpired(_ token: String) -> Bool {
+    guard let payload = decodeJWTPayload(token),
+      let exp = payload["exp"] as? TimeInterval
+    else { return true }
+    return Date(timeIntervalSince1970: exp) <= Date()
+  }
+
+  private func decodeJWTPayload(_ token: String) -> [String: Any]? {
     let parts = token.split(separator: ".")
     guard parts.count >= 2 else { return nil }
     var base64 = String(parts[1])
@@ -169,10 +186,9 @@ final class AuthManager: NSObject, ObservableObject {
       .replacingOccurrences(of: "_", with: "/")
     while base64.count % 4 != 0 { base64 += "=" }
     guard let data = Data(base64Encoded: base64),
-      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let sub = json["sub"] as? String
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     else { return nil }
-    return sub
+    return json
   }
 
   private static var presentingViewController: UIViewController? {

--- a/BiteLog/Auth/AuthManager.swift
+++ b/BiteLog/Auth/AuthManager.swift
@@ -18,7 +18,7 @@ final class AuthManager: NSObject, ObservableObject {
 
   override init() {
     super.init()
-    // 起動時にKeychainからトークンを復元（期限切れなら削除）
+    // 起動時にKeychainからトークンを復元（期限切れなら削除、期限が近ければ自動リフレッシュ）
     if let token = loadTokenFromKeychain() {
       if isTokenExpired(token) {
         deleteTokenFromKeychain()
@@ -27,6 +27,9 @@ final class AuthManager: NSObject, ObservableObject {
         self.isSignedIn = true
         self.userId = extractUserId(from: token)
         self.isAdmin = UserDefaults.standard.bool(forKey: isAdminKey)
+        if isTokenExpiringSoon(token) {
+          Task { await refreshSession() }
+        }
       }
     }
   }
@@ -43,6 +46,17 @@ final class AuthManager: NSObject, ObservableObject {
     self.isAdmin = isAdmin
     self.isSignedIn = true
     UserDefaults.standard.set(isAdmin, forKey: isAdminKey)
+  }
+
+  @discardableResult
+  func refreshSession() async -> Bool {
+    do {
+      let response = try await APIClient.shared.refreshToken()
+      storeToken(response.token, isAdmin: response.isAdmin)
+      return true
+    } catch {
+      return false
+    }
   }
 
   func signOut() {
@@ -176,6 +190,15 @@ final class AuthManager: NSObject, ObservableObject {
       let exp = payload["exp"] as? TimeInterval
     else { return true }
     return Date(timeIntervalSince1970: exp) <= Date()
+  }
+
+  // 7日以内に期限切れになるか確認
+  private func isTokenExpiringSoon(_ token: String) -> Bool {
+    guard let payload = decodeJWTPayload(token),
+      let exp = payload["exp"] as? TimeInterval
+    else { return true }
+    let sevenDaysFromNow = Date().addingTimeInterval(7 * 24 * 60 * 60)
+    return Date(timeIntervalSince1970: exp) <= sevenDaysFromNow
   }
 
   private func decodeJWTPayload(_ token: String) -> [String: Any]? {

--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -32,7 +32,8 @@ final class APIClient {
   private func request<T: Decodable>(
     path: String,
     method: String = "GET",
-    body: (any Encodable)? = nil
+    body: (any Encodable)? = nil,
+    isRetry: Bool = false
   ) async throws -> T {
     guard let url = URL(string: path, relativeTo: baseURL) else {
       throw APIError.invalidURL
@@ -66,6 +67,12 @@ final class APIClient {
     case 200...299:
       break
     case 401:
+      if !isRetry && !path.contains("/api/auth/") {
+        let refreshed = await AuthManager.shared.refreshSession()
+        if refreshed {
+          return try await request(path: path, method: method, body: body, isRetry: true)
+        }
+      }
       await AuthManager.shared.signOut()
       throw APIError.unauthorized
     case 404:
@@ -81,7 +88,7 @@ final class APIClient {
     }
   }
 
-  private func requestVoid(path: String, method: String, body: (any Encodable)? = nil) async throws {
+  private func requestVoid(path: String, method: String, body: (any Encodable)? = nil, isRetry: Bool = false) async throws {
     guard let url = URL(string: path, relativeTo: baseURL) else {
       throw APIError.invalidURL
     }
@@ -109,6 +116,12 @@ final class APIClient {
     switch http.statusCode {
     case 200...299: break
     case 401:
+      if !isRetry && !path.contains("/api/auth/") {
+        let refreshed = await AuthManager.shared.refreshSession()
+        if refreshed {
+          return try await requestVoid(path: path, method: method, body: body, isRetry: true)
+        }
+      }
       await AuthManager.shared.signOut()
       throw APIError.unauthorized
     case 404: throw APIError.notFound
@@ -218,6 +231,10 @@ final class APIClient {
   func signIn(provider: String, identityToken: String) async throws -> AuthResponse {
     let body = AuthRequest(provider: provider, identityToken: identityToken)
     return try await request(path: "/api/auth/signin", method: "POST", body: body)
+  }
+
+  func refreshToken() async throws -> AuthResponse {
+    return try await request(path: "/api/auth/refresh", method: "POST")
   }
 
   // MARK: - Export

--- a/cloudflare/src/routes/auth.ts
+++ b/cloudflare/src/routes/auth.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
-import { issueSessionJwt, verifyAppleToken, verifyGoogleToken } from '../middleware/auth';
-import type { Bindings } from '../types';
+import { authMiddleware, issueSessionJwt, verifyAppleToken, verifyGoogleToken } from '../middleware/auth';
+import type { Bindings, Variables } from '../types';
 
-const auth = new Hono<{ Bindings: Bindings }>();
+const auth = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 // POST /api/auth/signin
 // Body: { provider: "apple" | "google", identityToken: string }
@@ -35,6 +35,15 @@ auth.post('/signin', async (c) => {
 
   const sessionJwt = await issueSessionJwt(userId, c.env.WORKER_JWT_SECRET);
   const isAdmin = !!c.env.ADMIN_USER_ID && userId === c.env.ADMIN_USER_ID;
+  return c.json({ token: sessionJwt, userId, isAdmin });
+});
+
+// POST /api/auth/refresh
+// 現在有効なJWTで新しいJWT（30日）を発行する
+auth.post('/refresh', authMiddleware, async (c) => {
+  const userId = c.get('userId');
+  const isAdmin = c.get('isAdmin');
+  const sessionJwt = await issueSessionJwt(userId, c.env.WORKER_JWT_SECRET);
   return c.json({ token: sessionJwt, userId, isAdmin });
 });
 


### PR DESCRIPTION
## Summary

JWTセッションの自動リフレッシュを実装し、実質的に「使い続ける限りログアウトしない」動作を実現する。

Closes #79

## 背景

従来の実装ではJWTの有効期限（30日）が切れると再サインインが必要だった。一般的なアプリはリフレッシュトークンを使って自動更新しており、ユーザーが意識的にサインアウトしない限りログイン状態が維持される。

## 変更内容

### `cloudflare/src/routes/auth.ts`
`POST /api/auth/refresh` エンドポイントを追加。現在有効なJWTで認証し、新しいJWT（30日）を発行して返す。

### `BiteLog/Network/APIClient.swift`
- `request()` / `requestVoid()` に `isRetry` フラグを追加
- 401受信時にリフレッシュを試み、成功したら元のリクエストを自動再試行（ユーザーには透過的）
- `/api/auth/` へのリクエストはリフレッシュをスキップし無限ループを防止
- `refreshToken()` メソッドを追加

### `BiteLog/Auth/AuthManager.swift`
- `refreshSession()` メソッドを追加（`/api/auth/refresh` を呼び出し新トークンを保存）
- 起動時にJWTの `exp` を確認し、期限切れなら削除してサインイン画面へ遷移
- 起動時にJWTの期限が7日以内なら自動リフレッシュ（バックグラウンド）
- JWTデコードロジックを `decodeJWTPayload()` に集約し `extractUserId()` / `isTokenExpired()` / `isTokenExpiringSoon()` が共有

## 動作フロー

```
起動時
  → JWT期限が7日以内 → バックグラウンドで /api/auth/refresh → 新JWTを保存

API呼び出し時に401
  → /api/auth/refresh を試みる
      成功 → 元のリクエストを自動再試行（ユーザーには透過的）
      失敗 → signOut() → サインイン画面へ
```

## Test plan

- [ ] 期限切れJWTで起動するとサインイン画面が表示されることを確認
- [ ] 有効なJWTで起動した場合、従来通りログイン状態で起動することを確認
- [ ] JWTが期限切れの状態でAPIを呼び出すと自動リフレッシュされ、操作が継続できることを確認
- [ ] リフレッシュも失敗した場合（アカウント削除等）はサインイン画面に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)