### PR TITLE
feat: フードマスターの詳細表示と自分のデータフィルタリング

### DIFF
--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -131,9 +131,10 @@ final class APIClient {
 
   // MARK: - FoodMaster
 
-  func fetchFoodMasters(query: String = "", limit: Int = 30, offset: Int = 0) async throws -> FoodMasterListResponse {
+  func fetchFoodMasters(query: String = "", limit: Int = 30, offset: Int = 0, onlyMine: Bool = false) async throws -> FoodMasterListResponse {
     let q = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-    return try await request(path: "/api/food-masters?q=\(q)&limit=\(limit)&offset=\(offset)")
+    let mine = onlyMine ? "&onlyMine=true" : ""
+    return try await request(path: "/api/food-masters?q=\(q)&limit=\(limit)&offset=\(offset)\(mine)")
   }
 
   func createFoodMaster(_ dto: FoodMasterCreateDTO) async throws -> FoodMasterDTO {

--- a/BiteLog/Network/DTOs.swift
+++ b/BiteLog/Network/DTOs.swift
@@ -15,6 +15,7 @@ struct FoodMasterDTO: Codable, Identifiable, Hashable {
   var portionUnit: String
   var uniqueKey: String
   var createdBy: String?
+  var isMine: Bool?
   var usageCount: Int
   var lastUsedDate: Date?
   var lastNumberOfServings: Double

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -40,6 +40,8 @@
 "CSV File Format:" = "CSV File Format:";
 "Select CSV File" = "Select CSV File";
 "Close" = "Close";
+"Food Detail" = "Food Detail";
+"My Items" = "My Items";
 "Import Error" = "Import Error"; 
 "Import CSV" = "Import CSV";
 "Export CSV" = "Export CSV";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -53,6 +53,8 @@
 "CSV File Format:" = "CSVファイルのフォーマット:";
 "Select CSV File" = "CSVファイルを選択";
 "Close" = "閉じる";
+"Food Detail" = "食品詳細";
+"My Items" = "自分のみ";
 "Import Error" = "インポートエラー";
 "Import CSV" = "CSVインポート";
 "Export CSV" = "CSVエクスポート";

--- a/BiteLog/Views/FoodMasterManagementView.swift
+++ b/BiteLog/Views/FoodMasterManagementView.swift
@@ -6,8 +6,10 @@ struct FoodMasterManagementView: View {
   @State private var isInitialLoading = true
 
   @State private var searchText = ""
+  @State private var filterMyItems = false
   @State private var showingAddForm = false
   @State private var selectedFoodMaster: FoodMasterDTO?
+  @State private var viewingFoodMaster: FoodMasterDTO?
 
   @State private var currentPage = 0
   private let pageSize = 20
@@ -64,6 +66,28 @@ struct FoodMasterManagementView: View {
       .padding(.top, 8)
       .animation(.easeInOut(duration: 0.2), value: searchFieldIsFocused)
 
+      HStack {
+        Button {
+          filterMyItems.toggle()
+          Task { await resetAndSearch() }
+        } label: {
+          Label(
+            NSLocalizedString("My Items", comment: "My food items filter"),
+            systemImage: "person.fill"
+          )
+          .font(.subheadline.weight(.medium))
+          .padding(.horizontal, 12)
+          .padding(.vertical, 6)
+          .background(filterMyItems ? Color.blue : Color(UIColor.tertiarySystemFill))
+          .foregroundColor(filterMyItems ? .white : .primary)
+          .clipShape(Capsule())
+        }
+        Spacer()
+      }
+      .padding(.horizontal)
+      .padding(.bottom, 4)
+      .animation(.easeInOut(duration: 0.15), value: filterMyItems)
+
       if isInitialLoading {
         ProgressView()
           .padding()
@@ -75,9 +99,11 @@ struct FoodMasterManagementView: View {
             FoodMasterRow(foodMaster: foodMaster)
               .contentShape(Rectangle())
               .onTapGesture {
+                searchFieldIsFocused = false
                 if canEdit(foodMaster) {
                   selectedFoodMaster = foodMaster
-                  searchFieldIsFocused = false
+                } else {
+                  viewingFoodMaster = foodMaster
                 }
               }
               .onAppear {
@@ -141,6 +167,9 @@ struct FoodMasterManagementView: View {
     ) { foodMaster in
       FoodMasterFormView(mode: .edit(foodMaster))
     }
+    .sheet(item: $viewingFoodMaster, onDismiss: { viewingFoodMaster = nil }) { foodMaster in
+      FoodMasterDetailView(foodMaster: foodMaster)
+    }
     .onAppear {
       if !isDataLoaded { Task { await loadFoodMasters() } }
     }
@@ -164,7 +193,8 @@ struct FoodMasterManagementView: View {
       let resp = try await APIClient.shared.fetchFoodMasters(
         query: searchText,
         limit: pageSize,
-        offset: currentPage * pageSize
+        offset: currentPage * pageSize,
+        onlyMine: filterMyItems
       )
       await MainActor.run {
         if currentPage == 0 {
@@ -192,7 +222,7 @@ struct FoodMasterManagementView: View {
   }
 
   private func canEdit(_ foodMaster: FoodMasterDTO) -> Bool {
-    AuthManager.shared.isAdmin || foodMaster.createdBy == AuthManager.shared.userId
+    AuthManager.shared.isAdmin || foodMaster.isMine == true
   }
 
   private func deleteFoodMaster(_ foodMaster: FoodMasterDTO) {
@@ -202,6 +232,75 @@ struct FoodMasterManagementView: View {
         try await APIClient.shared.deleteFoodMaster(id: foodMaster.id)
       } catch {
         print("deleteFoodMaster error: \(error)")
+      }
+    }
+  }
+}
+
+// フードマスター詳細表示（読み取り専用）
+struct FoodMasterDetailView: View {
+  let foodMaster: FoodMasterDTO
+  @Environment(\.dismiss) var dismiss
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section(header: Text(NSLocalizedString("Basic Info", comment: "Basic info"))) {
+          LabeledContent(
+            NSLocalizedString("Brand Name", comment: "Brand name"),
+            value: foodMaster.brandName
+          )
+          LabeledContent(
+            NSLocalizedString("Product Name", comment: "Product name"),
+            value: foodMaster.productName
+          )
+          LabeledContent(
+            NSLocalizedString("Portion Size", comment: "Portion size"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.portionSize)) \(foodMaster.portionUnit)"
+          )
+        }
+
+        Section(
+          header: Text(
+            String(
+              format: NSLocalizedString(
+                "Nutrition (per %@ %@)", comment: "Nutrition with portion size and unit"),
+              NutritionFormatter.formatNutrition(foodMaster.portionSize),
+              foodMaster.portionUnit
+            ))
+        ) {
+          LabeledContent(
+            NSLocalizedString("Calories", comment: "Calories"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.calories)) kcal"
+          )
+          LabeledContent(
+            NSLocalizedString("Protein", comment: "Protein"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.protein)) g"
+          )
+          LabeledContent(
+            NSLocalizedString("Fat", comment: "Fat"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.fat)) g"
+          )
+          LabeledContent(
+            NSLocalizedString("Sugar", comment: "Sugar"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.netCarbs)) g"
+          )
+          LabeledContent(
+            NSLocalizedString("Dietary Fiber", comment: "Dietary Fiber"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.dietaryFiber)) g"
+          )
+          LabeledContent(
+            NSLocalizedString("Carbohydrates (Sugar + Fiber)", comment: "Carbohydrates"),
+            value: "\(NutritionFormatter.formatNutrition(foodMaster.netCarbs + foodMaster.dietaryFiber)) g"
+          )
+        }
+        .headerProminence(.increased)
+      }
+      .navigationTitle(NSLocalizedString("Food Detail", comment: "Food detail"))
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button(NSLocalizedString("Close", comment: "Close")) { dismiss() }
+        }
       }
     }
   }
@@ -258,6 +357,12 @@ struct FoodMasterRow: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       HStack(alignment: .firstTextBaseline) {
+        if foodMaster.isMine == true {
+          Image(systemName: "person.fill")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(.blue)
+            .padding(.top, 2)
+        }
         Text("\(foodMaster.brandName) \(foodMaster.productName)")
           .font(.subheadline.weight(.medium))
           .lineLimit(1)

--- a/cloudflare/src/routes/foodMasters.ts
+++ b/cloudflare/src/routes/foodMasters.ts
@@ -16,41 +16,47 @@ const FM_SELECT = `
 const FM_JOIN = `FROM food_masters fm
   LEFT JOIN user_food_stats ufs ON ufs.food_master_id = fm.id AND ufs.user_id = ?`;
 
-// GET /api/food-masters?q=&limit=20&offset=0
+// GET /api/food-masters?q=&limit=20&offset=0&onlyMine=true
 foodMasters.get('/', async (c) => {
   const userId = c.get('userId');
   const q = c.req.query('q') ?? '';
   const limit = Math.min(parseInt(c.req.query('limit') ?? '20'), 500);
   const offset = parseInt(c.req.query('offset') ?? '0');
+  const onlyMine = c.req.query('onlyMine') === 'true';
 
   let rows: FoodMasterRow[];
   let total: number;
 
   if (q) {
     const pattern = `%${q}%`;
+    const mineClause = onlyMine ? 'AND fm.created_by = ?' : '';
+    const mineBinds = onlyMine ? [userId] : [];
     const [dataResult, countResult] = await Promise.all([
       c.env.DB.prepare(
         `SELECT ${FM_SELECT} ${FM_JOIN}
-         WHERE (fm.brand_name LIKE ? OR fm.product_name LIKE ?)
+         WHERE (fm.brand_name LIKE ? OR fm.product_name LIKE ?) ${mineClause}
          ORDER BY usage_count DESC, ufs.last_used_date DESC
          LIMIT ? OFFSET ?`
-      ).bind(userId, pattern, pattern, limit, offset).all<FoodMasterRow>(),
+      ).bind(userId, pattern, pattern, ...mineBinds, limit, offset).all<FoodMasterRow>(),
       c.env.DB.prepare(
         `SELECT COUNT(*) as count FROM food_masters
-         WHERE brand_name LIKE ? OR product_name LIKE ?`
-      ).bind(pattern, pattern).first<{ count: number }>(),
+         WHERE (brand_name LIKE ? OR product_name LIKE ?) ${mineClause}`
+      ).bind(pattern, pattern, ...mineBinds).first<{ count: number }>(),
     ]);
     rows = dataResult.results;
     total = countResult?.count ?? 0;
   } else {
+    const mineClause = onlyMine ? 'WHERE fm.created_by = ?' : '';
+    const mineBinds = onlyMine ? [userId] : [];
+    const countClause = onlyMine ? 'WHERE created_by = ?' : '';
     const [dataResult, countResult] = await Promise.all([
       c.env.DB.prepare(
-        `SELECT ${FM_SELECT} ${FM_JOIN}
+        `SELECT ${FM_SELECT} ${FM_JOIN} ${mineClause}
          ORDER BY usage_count DESC, ufs.last_used_date DESC
          LIMIT ? OFFSET ?`
-      ).bind(userId, limit, offset).all<FoodMasterRow>(),
-      c.env.DB.prepare(`SELECT COUNT(*) as count FROM food_masters`)
-        .first<{ count: number }>(),
+      ).bind(userId, ...mineBinds, limit, offset).all<FoodMasterRow>(),
+      c.env.DB.prepare(`SELECT COUNT(*) as count FROM food_masters ${countClause}`)
+        .bind(...mineBinds).first<{ count: number }>(),
     ]);
     rows = dataResult.results;
     total = countResult?.count ?? 0;
@@ -60,6 +66,7 @@ foodMasters.get('/', async (c) => {
   return c.json({
     items: rows.map(r => ({
       ...foodMasterToResponse(r),
+      isMine: r.created_by === userId,
       ...(isAdmin ? { createdBy: r.created_by } : {}),
     })),
     total,


### PR DESCRIPTION
Closes #96

## 変更内容

### 詳細画面の追加（読み取り専用）
- 他のユーザーが登録したフードマスターをタップすると `FoodMasterDetailView`（読み取り専用）が開く
- 自分のデータはタップで編集フォームが開く（従来通り）

### 自分のデータフィルタリング
- 「自分のみ」フィルターチップを検索バー下に追加（オン時は青いカプセル）
- サーバー側で `onlyMine=true` クエリパラメーターによるフィルタリング

### 視覚的インジケーター
- 自分が登録したデータに青い `person.fill` アイコンを表示

### サーバー側
- 全ユーザーに `isMine: boolean` を返すよう追加
- `GET /api/food-masters` に `onlyMine` クエリパラメーターを追加
- `canEdit` を `isMine` フラグベースに修正

## テスト
- [ ] 自分のデータに `person.fill` アイコンが表示されること
- [ ] 「自分のみ」フィルターが正しく機能すること
- [ ] 他のユーザーのデータをタップすると詳細画面（読み取り専用）が開くこと
- [ ] 自分のデータをタップすると編集フォームが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)