### PR TITLE
feat: ログイン画面をパスワードのみの通常フォームに変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 BiteLog is an iOS application for meal tracking and nutrition management. Built with SwiftUI and SwiftData, it manages food nutrition data and records daily meals.
 
+The repository also contains a web admin console: `frontend/` (React SPA on Cloudflare Pages) and `cloudflare/` (Hono API on Cloudflare Workers + D1). See "Web Admin Console" below.
+
 ## Development Environment & Build Commands
 
 ### Required Tools
@@ -73,6 +75,53 @@ SweetPad: Generate Build Server Config
 - Minimum iOS version: iOS 18.2
 - Supported devices: iPhone only
 - Current version: 1.6
+
+## Web Admin Console (frontend / cloudflare)
+
+### Structure
+
+- Bun workspaces monorepo: `frontend/` + `cloudflare/`
+- `frontend/`: React 19 + Vite + Tailwind CSS v4. Deployed to Cloudflare Pages (`bitelog-admin.pages.dev`)
+- `cloudflare/`: Hono on Cloudflare Workers + D1. Deployed to `bitelog-workers.v10acdict.workers.dev`
+- Type-safe API calls via Hono RPC: `cloudflare/src/index.ts` exports `AppType`, consumed by `frontend/src/lib/api.ts`
+- Admin auth: password is checked against the `ADMIN_API_KEY` Worker secret via `GET /api/auth/verify` (sent as `Authorization: Bearer` on every request)
+
+### Local Development
+
+```bash
+# API (port 8787). Local secrets live in cloudflare/.dev.vars (gitignored)
+cd cloudflare && npm run dev
+
+# Frontend (port 5173). Connects to the production Worker by default;
+# to use the local Worker, copy .env.development.local.example to .env.development.local
+cd frontend && bun run dev
+```
+
+### Test & Build
+
+```bash
+cd cloudflare && npm test        # vitest
+cd frontend && bun run build     # includes tsc type check
+```
+
+### Deploy (manual — no git integration)
+
+Deploy the Worker first when the frontend depends on new API endpoints.
+
+```bash
+# 1. Worker
+cd cloudflare && npm run deploy
+
+# 2. Pages (--branch main is required; otherwise it becomes a preview deployment)
+cd frontend && bun run build
+cd ../cloudflare && npx wrangler pages deploy ../frontend/dist --project-name bitelog-admin --branch main
+```
+
+### Development Flow
+
+1. Create a GitHub issue describing the problem (why)
+2. Branch from up-to-date main — run `git fetch origin main` first; local main may be stale
+3. Open a PR with `Closes #N`. Verify the actual diff with `gh pr diff` before writing the description
 
 ## Testing Strategy
 

--- a/cloudflare/src/routes/auth.ts
+++ b/cloudflare/src/routes/auth.ts
@@ -38,6 +38,12 @@ auth.post('/signin', async (c) => {
   return c.json({ token: sessionJwt, userId, isAdmin });
 });
 
+// GET /api/auth/verify
+// 資格情報(管理キーまたはJWT)の有効性を確認する。管理画面のログイン検証に使う
+auth.get('/verify', authMiddleware, (c) => {
+  return c.json({ userId: c.get('userId'), isAdmin: c.get('isAdmin') });
+});
+
 // POST /api/auth/refresh
 // 現在有効なJWTで新しいJWT（30日）を発行する
 auth.post('/refresh', authMiddleware, async (c) => {

--- a/frontend/.env.development.local.example
+++ b/frontend/.env.development.local.example
@@ -1,0 +1,3 @@
+# ローカルのWorker(wrangler dev)に接続する場合は、このファイルを
+# .env.development.local にコピーして使う(*.localはgitignore済み)
+VITE_API_URL=http://localhost:8787

--- a/frontend/src/components/SetupModal.tsx
+++ b/frontend/src/components/SetupModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { motion } from 'motion/react';
-import { setToken, setApiUrl, getApiUrl } from '@/lib/auth';
+import { setToken, API_URL } from '@/lib/auth';
 
 interface Props {
   onAuthenticated: () => void;
@@ -8,8 +8,6 @@ interface Props {
 
 export default function SetupModal({ onAuthenticated }: Props) {
   const [password, setPassword] = useState('');
-  const [apiUrl, setApiUrlState] = useState(getApiUrl());
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -19,8 +17,7 @@ export default function SetupModal({ onAuthenticated }: Props) {
     setLoading(true);
 
     try {
-      setApiUrl(apiUrl);
-      const res = await fetch(`${apiUrl}/health`, {
+      const res = await fetch(`${API_URL}/api/auth/verify`, {
         headers: { Authorization: `Bearer ${password}` },
       });
 
@@ -70,7 +67,7 @@ export default function SetupModal({ onAuthenticated }: Props) {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">
-                Access Key
+                Password
               </label>
               <input
                 type="password"
@@ -82,29 +79,6 @@ export default function SetupModal({ onAuthenticated }: Props) {
                 autoFocus
               />
             </div>
-
-            <button
-              type="button"
-              onClick={() => setShowAdvanced(!showAdvanced)}
-              className="text-xs text-muted-foreground hover:text-neon-cyan transition-colors tracking-wider"
-            >
-              {showAdvanced ? '▲' : '▼'} ADVANCED
-            </button>
-
-            {showAdvanced && (
-              <div>
-                <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">
-                  API Endpoint
-                </label>
-                <input
-                  type="url"
-                  value={apiUrl}
-                  onChange={(e) => setApiUrlState(e.target.value)}
-                  className="w-full bg-bg-card border border-border-dim px-3 py-2 text-xs text-foreground focus:outline-none focus:border-neon-cyan transition-colors"
-                  style={{ fontFamily: 'inherit' }}
-                />
-              </div>
-            )}
 
             {error && (
               <p className="text-xs text-destructive tracking-wide">{error}</p>
@@ -123,7 +97,7 @@ export default function SetupModal({ onAuthenticated }: Props) {
                 boxShadow: loading ? 'none' : '0 0 15px rgba(0,229,255,0.3)',
               }}
             >
-              {loading ? 'CONNECTING...' : 'AUTHENTICATE'}
+              {loading ? 'CONNECTING...' : 'LOGIN'}
             </motion.button>
           </form>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,9 @@
 import { hc } from 'hono/client';
 import type { AppType } from '../../../cloudflare/src/index';
-import { getToken, getApiUrl } from './auth';
+import { getToken, API_URL } from './auth';
 
 export function createClient() {
-  return hc<AppType>(getApiUrl(), {
+  return hc<AppType>(API_URL, {
     headers: () => ({
       Authorization: `Bearer ${getToken()}`,
     }),

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,7 +1,7 @@
 const TOKEN_KEY = 'bitelog_admin_token';
-const API_URL_KEY = 'bitelog_api_url';
 
-const DEFAULT_API_URL = 'https://bitelog-workers.v10acdict.workers.dev';
+export const API_URL =
+  import.meta.env.VITE_API_URL ?? 'https://bitelog-workers.v10acdict.workers.dev';
 
 export function getToken(): string {
   return sessionStorage.getItem(TOKEN_KEY) ?? '';
@@ -17,12 +17,4 @@ export function clearToken(): void {
 
 export function isAuthenticated(): boolean {
   return getToken().length > 0;
-}
-
-export function getApiUrl(): string {
-  return localStorage.getItem(API_URL_KEY) ?? DEFAULT_API_URL;
-}
-
-export function setApiUrl(url: string): void {
-  localStorage.setItem(API_URL_KEY, url);
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Closes #102

## 概要

管理画面のログインを、パスワード1欄だけの通常のログインフォームにする(サイバーパンクUIは維持)。

## 変更内容

- API ENDPOINT欄とADVANCEDトグルを削除し、接続先URLをビルド時定数に固定
  - ローカル開発時は `VITE_API_URL` で上書き可能(`.env.development.local.example` 参照)
- ラベルを「Password」、ボタンを「LOGIN」に変更
- 認証必須の `GET /api/auth/verify` を追加し、ログイン時に資格情報を実際に検証するように修正
  - 従来は公開エンドポイント `/health` を見ていたため、任意のパスワードでログイン画面を通過できていた
- CLAUDE.mdに管理画面(frontend/cloudflare)の開発・デプロイ手順を追記

## 動作確認

- 誤パスワード → 「認証失敗」表示、正パスワード → ログイン成功(ローカルWorker + Playwrightで確認)
- 本番デプロイ済み: https://bitelog-admin.pages.dev で誤パスワードが拒否されることを確認
- `bun run build`(型チェック込み)、cloudflareのvitest 4件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)