### PR TITLE
feat: Web管理画面にApple/Googleログインを追加し一般ユーザーが自分のデータを閲覧・編集できるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,9 @@ SweetPad: Generate Build Server Config
 - `cloudflare/`: Hono on Cloudflare Workers + D1. Deployed to `bitelog-workers.v10acdict.workers.dev`
 - Type-safe API calls via Hono RPC: `cloudflare/src/index.ts` exports `AppType`, consumed by `frontend/src/lib/api.ts`
 - Admin auth: password is checked against the `ADMIN_API_KEY` Worker secret via `GET /api/auth/verify` (sent as `Authorization: Bearer` on every request)
+- User auth (social login): the login screen also offers Sign in with Apple / Google. The identity token goes to `POST /api/auth/signin`, which returns a 30-day session JWT tied to the same `userId` as the iOS app. Regular users see and edit only their own data (`isAdmin: false`)
+  - Worker secrets: `GOOGLE_WEB_CLIENT_ID` (web OAuth client in the same Google Cloud project as iOS), `APPLE_WEB_SERVICE_ID` (Apple Services ID, e.g. `com.watahiki.BiteLog.web`)
+  - Frontend build-time vars: `VITE_GOOGLE_CLIENT_ID`, `VITE_APPLE_SERVICE_ID` (see `frontend/.env.example`). Buttons are hidden when unset; Apple is also hidden on non-https origins (localhost) because Apple return URLs cannot point to localhost
 
 ### Local Development
 

--- a/cloudflare/src/middleware/auth.test.ts
+++ b/cloudflare/src/middleware/auth.test.ts
@@ -1,0 +1,173 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+import { verifyAppleToken, verifyGoogleToken } from './auth';
+
+const IOS_BUNDLE_ID = 'com.watahiki.BiteLog';
+const WEB_SERVICE_ID = 'com.watahiki.BiteLog.web';
+const IOS_GOOGLE_CLIENT = 'ios-client.apps.googleusercontent.com';
+const WEB_GOOGLE_CLIENT = 'web-client.apps.googleusercontent.com';
+
+let privateKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair('RS256', { extractable: true });
+  privateKey = pair.privateKey as CryptoKey;
+  const publicJwk = {
+    ...(await exportJWK(pair.publicKey as CryptoKey)),
+    kid: 'test-kid',
+    alg: 'RS256',
+    use: 'sig',
+  };
+
+  // Apple/GoogleのJWKS取得をモック
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (
+      url === 'https://appleid.apple.com/auth/keys' ||
+      url === 'https://www.googleapis.com/oauth2/v3/certs'
+    ) {
+      return Response.json({ keys: [publicJwk] });
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+async function signIdentityToken(opts: {
+  iss: string;
+  aud: string;
+  sub?: string;
+  expiresIn?: string;
+}): Promise<string> {
+  return await new SignJWT({})
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-kid' })
+    .setIssuer(opts.iss)
+    .setAudience(opts.aud)
+    .setSubject(opts.sub ?? 'user-123')
+    .setIssuedAt()
+    .setExpirationTime(opts.expiresIn ?? '1h')
+    .sign(privateKey);
+}
+
+// 署名中間のビットを反転する（末尾文字はbase64urlの詰め物ビットのみの場合があり改ざんにならない）
+function tamperSignature(token: string): string {
+  const [h, p, sig] = token.split('.');
+  const i = 10;
+  const flipped = sig[i] === 'A' ? 'B' : 'A';
+  return `${h}.${p}.${sig.slice(0, i)}${flipped}${sig.slice(i + 1)}`;
+}
+
+describe('verifyAppleToken', () => {
+  const allowed = [IOS_BUNDLE_ID, WEB_SERVICE_ID];
+
+  it('iOSバンドルIDのaudを持つトークンを受理する(回帰)', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://appleid.apple.com',
+      aud: IOS_BUNDLE_ID,
+      sub: 'apple-sub-1',
+    });
+    expect(await verifyAppleToken(token, allowed)).toBe('apple:apple-sub-1');
+  });
+
+  it('許可リストに含まれるWeb Services IDのaudを受理する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://appleid.apple.com',
+      aud: WEB_SERVICE_ID,
+      sub: 'apple-sub-1',
+    });
+    expect(await verifyAppleToken(token, allowed)).toBe('apple:apple-sub-1');
+  });
+
+  it('許可リスト外のaudは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://appleid.apple.com',
+      aud: 'com.evil.app',
+    });
+    await expect(verifyAppleToken(token, allowed)).rejects.toThrow();
+  });
+
+  it('期限切れトークンは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://appleid.apple.com',
+      aud: IOS_BUNDLE_ID,
+      expiresIn: '-1h',
+    });
+    await expect(verifyAppleToken(token, allowed)).rejects.toThrow();
+  });
+
+  it('issが不正なトークンは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://evil.example.com',
+      aud: IOS_BUNDLE_ID,
+    });
+    await expect(verifyAppleToken(token, allowed)).rejects.toThrow();
+  });
+
+  it('署名が不正なトークンは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://appleid.apple.com',
+      aud: IOS_BUNDLE_ID,
+    });
+    await expect(verifyAppleToken(tamperSignature(token), allowed)).rejects.toThrow();
+  });
+});
+
+describe('verifyGoogleToken', () => {
+  const allowed = [IOS_GOOGLE_CLIENT, WEB_GOOGLE_CLIENT];
+
+  it('iOSクライアントIDのaudを持つトークンを受理する(回帰)', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://accounts.google.com',
+      aud: IOS_GOOGLE_CLIENT,
+      sub: 'google-sub-1',
+    });
+    expect(await verifyGoogleToken(token, allowed)).toBe('google:google-sub-1');
+  });
+
+  it('許可リストに含まれるWebクライアントIDのaudを受理する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://accounts.google.com',
+      aud: WEB_GOOGLE_CLIENT,
+      sub: 'google-sub-1',
+    });
+    expect(await verifyGoogleToken(token, allowed)).toBe('google:google-sub-1');
+  });
+
+  it('iss が accounts.google.com (httpsなし) のトークンも受理する', async () => {
+    const token = await signIdentityToken({
+      iss: 'accounts.google.com',
+      aud: WEB_GOOGLE_CLIENT,
+      sub: 'google-sub-1',
+    });
+    expect(await verifyGoogleToken(token, allowed)).toBe('google:google-sub-1');
+  });
+
+  it('許可リスト外のaudは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://accounts.google.com',
+      aud: 'other-client.apps.googleusercontent.com',
+    });
+    await expect(verifyGoogleToken(token, allowed)).rejects.toThrow();
+  });
+
+  it('期限切れトークンは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://accounts.google.com',
+      aud: IOS_GOOGLE_CLIENT,
+      expiresIn: '-1h',
+    });
+    await expect(verifyGoogleToken(token, allowed)).rejects.toThrow();
+  });
+
+  it('署名が不正なトークンは拒否する', async () => {
+    const token = await signIdentityToken({
+      iss: 'https://accounts.google.com',
+      aud: IOS_GOOGLE_CLIENT,
+    });
+    await expect(verifyGoogleToken(tamperSignature(token), allowed)).rejects.toThrow();
+  });
+});

--- a/cloudflare/src/middleware/auth.ts
+++ b/cloudflare/src/middleware/auth.ts
@@ -5,6 +5,9 @@ import type { Bindings, Variables } from '../types';
 const APPLE_KEYS_URL = 'https://appleid.apple.com/auth/keys';
 const GOOGLE_KEYS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
 
+// iOSアプリのBundle ID（Appleトークンのaud）
+export const APPLE_BUNDLE_ID = 'com.watahiki.BiteLog';
+
 // セッションJWT発行（有効期限30日）
 export async function issueSessionJwt(userId: string, secret: string): Promise<string> {
   const key = new TextEncoder().encode(secret);
@@ -27,7 +30,11 @@ export async function verifySessionJwt(
 }
 
 // Apple identityToken検証（RS256）
-export async function verifyAppleToken(identityToken: string): Promise<string> {
+// allowedAudiences: iOSのBundle IDとWeb用Services IDの両方を受理する
+export async function verifyAppleToken(
+  identityToken: string,
+  allowedAudiences: string[]
+): Promise<string> {
   const res = await fetch(APPLE_KEYS_URL);
   const { keys } = (await res.json()) as { keys: JsonWebKey[] };
 
@@ -55,13 +62,17 @@ export async function verifyAppleToken(identityToken: string): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   if (!payload.exp || payload.exp < now) throw new Error('Apple token expired');
   if (payload.iss !== 'https://appleid.apple.com') throw new Error('Invalid Apple token issuer');
-  if (payload.aud !== 'com.watahiki.BiteLog') throw new Error('Invalid Apple token audience');
+  if (!allowedAudiences.includes(payload.aud)) throw new Error('Invalid Apple token audience');
   if (!payload.sub) throw new Error('No sub in Apple token');
   return `apple:${payload.sub}`;
 }
 
 // Google identityToken検証
-export async function verifyGoogleToken(identityToken: string, googleClientId: string): Promise<string> {
+// allowedAudiences: iOS用とWeb用のOAuthクライアントIDの両方を受理する
+export async function verifyGoogleToken(
+  identityToken: string,
+  allowedAudiences: string[]
+): Promise<string> {
   const res = await fetch(GOOGLE_KEYS_URL);
   const { keys } = (await res.json()) as { keys: JsonWebKey[] };
 
@@ -87,8 +98,11 @@ export async function verifyGoogleToken(identityToken: string, googleClientId: s
   const payload = JSON.parse(atob(payloadB64));
   const now = Math.floor(Date.now() / 1000);
   if (!payload.exp || payload.exp < now) throw new Error('Google token expired');
-  if (payload.iss !== 'https://accounts.google.com') throw new Error('Invalid Google token issuer');
-  if (payload.aud !== googleClientId) throw new Error('Invalid Google token audience');
+  // issはhttpsあり/なしの両形式がある (https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken)
+  if (payload.iss !== 'https://accounts.google.com' && payload.iss !== 'accounts.google.com') {
+    throw new Error('Invalid Google token issuer');
+  }
+  if (!allowedAudiences.includes(payload.aud)) throw new Error('Invalid Google token audience');
   if (!payload.sub) throw new Error('No sub in Google token');
   return `google:${payload.sub}`;
 }

--- a/cloudflare/src/routes/auth.test.ts
+++ b/cloudflare/src/routes/auth.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+import app from '../index';
+
+const IOS_BUNDLE_ID = 'com.watahiki.BiteLog';
+const WEB_SERVICE_ID = 'com.watahiki.BiteLog.web';
+const IOS_GOOGLE_CLIENT = 'ios-client.apps.googleusercontent.com';
+const WEB_GOOGLE_CLIENT = 'web-client.apps.googleusercontent.com';
+
+const TEST_ENV = {
+  WORKER_JWT_SECRET: 'signin-test-secret',
+  GOOGLE_CLIENT_ID: IOS_GOOGLE_CLIENT,
+  GOOGLE_WEB_CLIENT_ID: WEB_GOOGLE_CLIENT,
+  APPLE_WEB_SERVICE_ID: WEB_SERVICE_ID,
+};
+
+let privateKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair('RS256', { extractable: true });
+  privateKey = pair.privateKey as CryptoKey;
+  const publicJwk = {
+    ...(await exportJWK(pair.publicKey as CryptoKey)),
+    kid: 'test-kid',
+    alg: 'RS256',
+    use: 'sig',
+  };
+
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (
+      url === 'https://appleid.apple.com/auth/keys' ||
+      url === 'https://www.googleapis.com/oauth2/v3/certs'
+    ) {
+      return Response.json({ keys: [publicJwk] });
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+async function signIdentityToken(iss: string, aud: string, sub: string): Promise<string> {
+  return await new SignJWT({})
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-kid' })
+    .setIssuer(iss)
+    .setAudience(aud)
+    .setSubject(sub)
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(privateKey);
+}
+
+function signin(provider: string, identityToken: string, env: object = TEST_ENV) {
+  return app.request(
+    '/api/auth/signin',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider, identityToken }),
+    },
+    env
+  );
+}
+
+describe('POST /api/auth/signin', () => {
+  it('Google WebクライアントIDのトークンでサインインできる', async () => {
+    const token = await signIdentityToken(
+      'https://accounts.google.com', WEB_GOOGLE_CLIENT, 'g-sub'
+    );
+    const res = await signin('google', token);
+
+    expect(res.status).toBe(200);
+    const body = await res.json<{ token: string; userId: string; isAdmin: boolean }>();
+    expect(body.userId).toBe('google:g-sub');
+    expect(body.token).toBeTruthy();
+  });
+
+  it('Apple Web Services IDのトークンでサインインできる', async () => {
+    const token = await signIdentityToken(
+      'https://appleid.apple.com', WEB_SERVICE_ID, 'a-sub'
+    );
+    const res = await signin('apple', token);
+
+    expect(res.status).toBe(200);
+    const body = await res.json<{ userId: string }>();
+    expect(body.userId).toBe('apple:a-sub');
+  });
+
+  it('iOSのaudのトークンも引き続きサインインできる(回帰)', async () => {
+    const apple = await signin(
+      'apple',
+      await signIdentityToken('https://appleid.apple.com', IOS_BUNDLE_ID, 'a-sub')
+    );
+    const google = await signin(
+      'google',
+      await signIdentityToken('https://accounts.google.com', IOS_GOOGLE_CLIENT, 'g-sub')
+    );
+    expect(apple.status).toBe(200);
+    expect(google.status).toBe(200);
+  });
+
+  it('許可リスト外のaudのトークンは401になる', async () => {
+    const res = await signin(
+      'google',
+      await signIdentityToken('https://accounts.google.com', 'evil-client', 'g-sub')
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('Web用ID未設定の環境でもiOSのaudは受理される', async () => {
+    const envWithoutWebIds = {
+      WORKER_JWT_SECRET: 'signin-test-secret',
+      GOOGLE_CLIENT_ID: IOS_GOOGLE_CLIENT,
+    };
+    const res = await signin(
+      'google',
+      await signIdentityToken('https://accounts.google.com', IOS_GOOGLE_CLIENT, 'g-sub'),
+      envWithoutWebIds
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('signinで得たトークンで /api/auth/verify が通る', async () => {
+    const signinRes = await signin(
+      'google',
+      await signIdentityToken('https://accounts.google.com', WEB_GOOGLE_CLIENT, 'g-sub')
+    );
+    const { token } = await signinRes.json<{ token: string }>();
+
+    const verifyRes = await app.request(
+      '/api/auth/verify',
+      { headers: { Authorization: `Bearer ${token}` } },
+      TEST_ENV
+    );
+
+    expect(verifyRes.status).toBe(200);
+    const body = await verifyRes.json<{ userId: string; isAdmin: boolean }>();
+    expect(body.userId).toBe('google:g-sub');
+    expect(body.isAdmin).toBe(false);
+  });
+});

--- a/cloudflare/src/routes/auth.ts
+++ b/cloudflare/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { authMiddleware, issueSessionJwt, verifyAppleToken, verifyGoogleToken } from '../middleware/auth';
+import { APPLE_BUNDLE_ID, authMiddleware, issueSessionJwt, verifyAppleToken, verifyGoogleToken } from '../middleware/auth';
 import type { Bindings, Variables } from '../types';
 
 const auth = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -22,9 +22,9 @@ auth.post('/signin', async (c) => {
   let userId: string;
   try {
     if (provider === 'apple') {
-      userId = await verifyAppleToken(identityToken);
+      userId = await verifyAppleToken(identityToken, [APPLE_BUNDLE_ID]);
     } else if (provider === 'google') {
-      userId = await verifyGoogleToken(identityToken, c.env.GOOGLE_CLIENT_ID);
+      userId = await verifyGoogleToken(identityToken, [c.env.GOOGLE_CLIENT_ID]);
     } else {
       return c.json({ error: 'Unsupported provider' }, 400);
     }

--- a/cloudflare/src/routes/auth.ts
+++ b/cloudflare/src/routes/auth.ts
@@ -22,9 +22,17 @@ auth.post('/signin', async (c) => {
   let userId: string;
   try {
     if (provider === 'apple') {
-      userId = await verifyAppleToken(identityToken, [APPLE_BUNDLE_ID]);
+      // iOSアプリ(Bundle ID)とWeb(Services ID)の両方を受理する
+      const allowedAudiences = [APPLE_BUNDLE_ID, c.env.APPLE_WEB_SERVICE_ID].filter(
+        (aud): aud is string => !!aud
+      );
+      userId = await verifyAppleToken(identityToken, allowedAudiences);
     } else if (provider === 'google') {
-      userId = await verifyGoogleToken(identityToken, [c.env.GOOGLE_CLIENT_ID]);
+      // iOS用とWeb用のOAuthクライアントIDの両方を受理する
+      const allowedAudiences = [c.env.GOOGLE_CLIENT_ID, c.env.GOOGLE_WEB_CLIENT_ID].filter(
+        (aud): aud is string => !!aud
+      );
+      userId = await verifyGoogleToken(identityToken, allowedAudiences);
     } else {
       return c.json({ error: 'Unsupported provider' }, 400);
     }

--- a/cloudflare/src/types.ts
+++ b/cloudflare/src/types.ts
@@ -4,6 +4,9 @@ export type Bindings = {
   ADMIN_API_KEY: string;
   ADMIN_USER_ID: string;
   GOOGLE_CLIENT_ID: string;
+  // Web管理画面のソーシャルログイン用（未設定の場合はWebからのサインイン不可）
+  GOOGLE_WEB_CLIENT_ID?: string;
+  APPLE_WEB_SERVICE_ID?: string;
   OPENAI_API_KEY: string;
 };
 

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -12,5 +12,9 @@ database_id = "cf39b710-956c-4f27-ae1a-6dbf7a6a0fef"
 # 本番では wrangler secret put WORKER_JWT_SECRET で上書きすること
 WORKER_JWT_SECRET = "dev-and-test-secret"
 
+# Web管理画面のソーシャルログインを有効にするには、以下も wrangler secret put で設定する
+# - GOOGLE_WEB_CLIENT_ID: Google Cloud ConsoleのWebアプリ用OAuthクライアントID（iOSと同じプロジェクト）
+# - APPLE_WEB_SERVICE_ID: Apple DeveloperのServices ID（例: com.watahiki.BiteLog.web）
+
 [dev]
 port = 8787

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,13 @@
+# ソーシャルログイン用の公開ID。実際の値を入れて .env として保存する(ビルド時に埋め込まれる)
+# クライアントID/Services IDは公開情報なのでコミットしても問題ないが、環境ごとに変えられるようexample管理とする
+
+# Google Cloud Console > 認証情報 > OAuthクライアントID(Webアプリケーション)
+# 承認済みJavaScript生成元: https://bitelog-admin.pages.dev と http://localhost:5173
+VITE_GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
+
+# Apple Developer > Identifiers > Services ID (Sign in with Appleを有効化し、
+# Domains: bitelog-admin.pages.dev / Return URL: https://bitelog-admin.pages.dev を登録)
+VITE_APPLE_SERVICE_ID=com.watahiki.BiteLog.web
+
+# AppleのReturn URL(省略時は現在のオリジン)
+# VITE_APPLE_REDIRECT_URI=https://bitelog-admin.pages.dev

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://bitelog-workers.v10acdict.workers.dev; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client https://appleid.cdn-apple.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com/gsi/style; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://bitelog-workers.v10acdict.workers.dev https://accounts.google.com/gsi/; frame-src https://accounts.google.com/gsi/ https://appleid.apple.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: same-origin

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,7 @@ export default function App() {
         isAdmin={session.isAdmin}
       />
       <main className="flex-1 flex flex-col overflow-hidden bg-bg-deep">
-        {activeTab === 'food' && <FoodMasterPage onToast={addToast} />}
+        {activeTab === 'food' && <FoodMasterPage onToast={addToast} isAdmin={session.isAdmin} />}
         {activeTab === 'log' && <MealLogPage onToast={addToast} />}
         {activeTab === 'goals' && <NutritionGoalsPage onToast={addToast} />}
       </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { isAuthenticated } from '@/lib/auth';
+import { getSession } from '@/lib/auth';
 import SetupModal from '@/components/SetupModal';
 import Sidebar from '@/components/Sidebar';
 import Toast, { type ToastMessage } from '@/components/Toast';
@@ -10,7 +10,7 @@ import NutritionGoalsPage from '@/pages/NutritionGoalsPage';
 type Tab = 'food' | 'log' | 'goals';
 
 export default function App() {
-  const [authed, setAuthed] = useState(isAuthenticated());
+  const [session, setSession] = useState(getSession());
   const [activeTab, setActiveTab] = useState<Tab>('food');
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
 
@@ -23,8 +23,8 @@ export default function App() {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  if (!authed) {
-    return <SetupModal onAuthenticated={() => setAuthed(true)} />;
+  if (!session) {
+    return <SetupModal onAuthenticated={() => setSession(getSession())} />;
   }
 
   return (
@@ -32,7 +32,8 @@ export default function App() {
       <Sidebar
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        onLogout={() => setAuthed(false)}
+        onLogout={() => setSession(null)}
+        isAdmin={session.isAdmin}
       />
       <main className="flex-1 flex flex-col overflow-hidden bg-bg-deep">
         {activeTab === 'food' && <FoodMasterPage onToast={addToast} />}

--- a/frontend/src/components/SetupModal.tsx
+++ b/frontend/src/components/SetupModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { motion } from 'motion/react';
-import { setToken, API_URL } from '@/lib/auth';
+import { setSession, API_URL } from '@/lib/auth';
 
 interface Props {
   onAuthenticated: () => void;
@@ -27,7 +27,8 @@ export default function SetupModal({ onAuthenticated }: Props) {
         return;
       }
 
-      setToken(password);
+      const { userId, isAdmin } = (await res.json()) as { userId: string; isAdmin: boolean };
+      setSession({ token: password, userId, isAdmin });
       onAuthenticated();
     } catch {
       setError('接続エラー: APIサーバーに到達できません');

--- a/frontend/src/components/SetupModal.tsx
+++ b/frontend/src/components/SetupModal.tsx
@@ -1,6 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion } from 'motion/react';
 import { setSession, API_URL } from '@/lib/auth';
+import {
+  isAppleLoginConfigured,
+  isGoogleLoginConfigured,
+  renderGoogleButton,
+  signInWithApple,
+} from '@/lib/socialAuth';
 
 interface Props {
   onAuthenticated: () => void;
@@ -10,6 +16,34 @@ export default function SetupModal({ onAuthenticated }: Props) {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showAdminForm, setShowAdminForm] = useState(false);
+  const googleButtonRef = useRef<HTMLDivElement>(null);
+
+  const googleEnabled = isGoogleLoginConfigured();
+  const appleEnabled = isAppleLoginConfigured();
+  const socialEnabled = googleEnabled || appleEnabled;
+
+  useEffect(() => {
+    if (!googleEnabled || !googleButtonRef.current) return;
+    renderGoogleButton(
+      googleButtonRef.current,
+      onAuthenticated,
+      () => setError('Googleサインインに失敗しました')
+    ).catch(() => setError('Googleサインインの読み込みに失敗しました'));
+  }, [googleEnabled, onAuthenticated]);
+
+  async function handleAppleSignIn() {
+    setError('');
+    try {
+      await signInWithApple();
+      onAuthenticated();
+    } catch (err) {
+      // ユーザーがポップアップを閉じた場合もrejectされるため、メッセージは控えめにする
+      if (err instanceof Error && err.message.includes('サインイン')) {
+        setError(err.message);
+      }
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -61,46 +95,82 @@ export default function SetupModal({ onAuthenticated }: Props) {
               BITELOG
             </div>
             <div className="text-muted-foreground text-xs tracking-widest uppercase">
-              Admin Access Terminal
+              Access Terminal
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">
-                Password
-              </label>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full bg-bg-card border border-border-dim px-3 py-2 text-sm text-foreground focus:outline-none focus:border-neon-cyan transition-colors"
-                style={{ fontFamily: 'inherit' }}
-                placeholder="••••••••"
-                autoFocus
-              />
+          {socialEnabled && (
+            <div className="space-y-3 mb-6">
+              {googleEnabled && (
+                <div ref={googleButtonRef} className="flex justify-center" />
+              )}
+              {appleEnabled && (
+                <motion.button
+                  type="button"
+                  onClick={handleAppleSignIn}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className="w-full py-2.5 text-sm font-medium bg-white text-black flex items-center justify-center gap-2"
+                  style={{ borderRadius: 4 }}
+                >
+                  <span aria-hidden="true"></span>
+                  Appleでサインイン
+                </motion.button>
+              )}
             </div>
+          )}
 
-            {error && (
-              <p className="text-xs text-destructive tracking-wide">{error}</p>
+          {error && (
+            <p className="text-xs text-destructive tracking-wide mb-4">{error}</p>
+          )}
+
+          {/* 管理者用パスワードログイン(折りたたみ) */}
+          <div className={socialEnabled ? 'border-t border-border-dim pt-4' : ''}>
+            {socialEnabled && (
+              <button
+                type="button"
+                onClick={() => setShowAdminForm((v) => !v)}
+                className="w-full text-left text-xs text-muted-foreground tracking-widest uppercase hover:text-neon-cyan transition-colors"
+              >
+                {showAdminForm ? '▾' : '▸'} Admin Access
+              </button>
             )}
 
-            <motion.button
-              type="submit"
-              disabled={loading || !password}
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
-              className="w-full py-2 text-sm font-bold tracking-widest uppercase transition-all disabled:opacity-40"
-              style={{
-                background: loading ? 'transparent' : 'rgba(0,229,255,0.1)',
-                border: '1px solid #00e5ff',
-                color: '#00e5ff',
-                boxShadow: loading ? 'none' : '0 0 15px rgba(0,229,255,0.3)',
-              }}
-            >
-              {loading ? 'CONNECTING...' : 'LOGIN'}
-            </motion.button>
-          </form>
+            {(!socialEnabled || showAdminForm) && (
+              <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+                <div>
+                  <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">
+                    Password
+                  </label>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full bg-bg-card border border-border-dim px-3 py-2 text-sm text-foreground focus:outline-none focus:border-neon-cyan transition-colors"
+                    style={{ fontFamily: 'inherit' }}
+                    placeholder="••••••••"
+                    autoFocus
+                  />
+                </div>
+
+                <motion.button
+                  type="submit"
+                  disabled={loading || !password}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className="w-full py-2 text-sm font-bold tracking-widest uppercase transition-all disabled:opacity-40"
+                  style={{
+                    background: loading ? 'transparent' : 'rgba(0,229,255,0.1)',
+                    border: '1px solid #00e5ff',
+                    color: '#00e5ff',
+                    boxShadow: loading ? 'none' : '0 0 15px rgba(0,229,255,0.3)',
+                  }}
+                >
+                  {loading ? 'CONNECTING...' : 'LOGIN'}
+                </motion.button>
+              </form>
+            )}
+          </div>
         </div>
       </motion.div>
     </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import { clearToken } from '@/lib/auth';
+import { clearSession } from '@/lib/auth';
 
 type Tab = 'food' | 'log' | 'goals';
 
@@ -7,6 +7,7 @@ interface Props {
   activeTab: Tab;
   onTabChange: (tab: Tab) => void;
   onLogout: () => void;
+  isAdmin: boolean;
 }
 
 const tabs: { id: Tab; label: string; icon: string }[] = [
@@ -15,9 +16,9 @@ const tabs: { id: Tab; label: string; icon: string }[] = [
   { id: 'goals', label: 'NUTRITION', icon: '◇' },
 ];
 
-export default function Sidebar({ activeTab, onTabChange, onLogout }: Props) {
+export default function Sidebar({ activeTab, onTabChange, onLogout, isAdmin }: Props) {
   function handleLogout() {
-    clearToken();
+    clearSession();
     onLogout();
   }
 
@@ -29,7 +30,9 @@ export default function Sidebar({ activeTab, onTabChange, onLogout }: Props) {
       {/* ブランド */}
       <div className="px-5 py-6 border-b border-border-dim">
         <GlitchText text="BITELOG" />
-        <div className="text-xs text-muted-foreground tracking-widest mt-1">ADMIN v2.0</div>
+        <div className="text-xs text-muted-foreground tracking-widest mt-1">
+          {isAdmin ? 'ADMIN v2.0' : 'USER MODE'}
+        </div>
       </div>
 
       {/* ナビゲーション */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,12 +1,21 @@
 import { hc } from 'hono/client';
 import type { AppType } from '../../../cloudflare/src/index';
-import { getToken, API_URL } from './auth';
+import { getToken, clearSession, API_URL } from './auth';
 
 export function createClient() {
   return hc<AppType>(API_URL, {
     headers: () => ({
       Authorization: `Bearer ${getToken()}`,
     }),
+    // セッションJWT失効時はログイン画面に戻す
+    fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+      const res = await fetch(input, init);
+      if (res.status === 401) {
+        clearSession();
+        window.location.reload();
+      }
+      return res;
+    },
   });
 }
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,20 +1,40 @@
 const TOKEN_KEY = 'bitelog_admin_token';
+const USER_KEY = 'bitelog_session_user';
 
 export const API_URL =
   import.meta.env.VITE_API_URL ?? 'https://bitelog-workers.v10acdict.workers.dev';
+
+export interface Session {
+  token: string;
+  userId: string;
+  isAdmin: boolean;
+}
 
 export function getToken(): string {
   return sessionStorage.getItem(TOKEN_KEY) ?? '';
 }
 
-export function setToken(token: string): void {
-  sessionStorage.setItem(TOKEN_KEY, token);
+export function setSession(session: Session): void {
+  sessionStorage.setItem(TOKEN_KEY, session.token);
+  sessionStorage.setItem(
+    USER_KEY,
+    JSON.stringify({ userId: session.userId, isAdmin: session.isAdmin })
+  );
 }
 
-export function clearToken(): void {
+export function getSession(): Session | null {
+  const token = getToken();
+  const user = sessionStorage.getItem(USER_KEY);
+  if (!token || !user) return null;
+  try {
+    const { userId, isAdmin } = JSON.parse(user) as { userId: string; isAdmin: boolean };
+    return { token, userId, isAdmin };
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession(): void {
   sessionStorage.removeItem(TOKEN_KEY);
-}
-
-export function isAuthenticated(): boolean {
-  return getToken().length > 0;
+  sessionStorage.removeItem(USER_KEY);
 }

--- a/frontend/src/lib/socialAuth.ts
+++ b/frontend/src/lib/socialAuth.ts
@@ -1,0 +1,135 @@
+import { API_URL, setSession, type Session } from './auth';
+
+// Google Identity Services / Sign in with Apple JS の型(必要な範囲のみ)
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize(config: {
+            client_id: string;
+            callback: (response: { credential: string }) => void;
+          }): void;
+          renderButton(
+            parent: HTMLElement,
+            options: { theme: string; size: string; width: number; text: string }
+          ): void;
+        };
+      };
+    };
+    AppleID?: {
+      auth: {
+        init(config: {
+          clientId: string;
+          scope: string;
+          redirectURI: string;
+          usePopup: boolean;
+        }): void;
+        signIn(): Promise<{ authorization: { id_token: string } }>;
+      };
+    };
+  }
+}
+
+const GIS_SRC = 'https://accounts.google.com/gsi/client';
+const APPLE_SRC =
+  'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/ja_JP/appleid.auth.js';
+
+const scriptPromises = new Map<string, Promise<void>>();
+
+function loadScript(src: string): Promise<void> {
+  let promise = scriptPromises.get(src);
+  if (!promise) {
+    promise = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.onload = () => resolve();
+      script.onerror = () => {
+        scriptPromises.delete(src);
+        reject(new Error(`Failed to load ${src}`));
+      };
+      document.head.appendChild(script);
+    });
+    scriptPromises.set(src, promise);
+  }
+  return promise;
+}
+
+export function isGoogleLoginConfigured(): boolean {
+  return !!import.meta.env.VITE_GOOGLE_CLIENT_ID;
+}
+
+// AppleのReturn URLにlocalhostは登録できないため、ローカル開発では無効化する
+export function isAppleLoginConfigured(): boolean {
+  return !!import.meta.env.VITE_APPLE_SERVICE_ID && window.location.protocol === 'https:';
+}
+
+// identityTokenをWorkerに送ってセッションJWTを取得・保存する
+async function signinWithIdentityToken(
+  provider: 'apple' | 'google',
+  identityToken: string
+): Promise<Session> {
+  const res = await fetch(`${API_URL}/api/auth/signin`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ provider, identityToken }),
+  });
+  if (!res.ok) {
+    throw new Error('サインインに失敗しました');
+  }
+  const { token, userId, isAdmin } = (await res.json()) as {
+    token: string;
+    userId: string;
+    isAdmin: boolean;
+  };
+  const session = { token, userId, isAdmin };
+  setSession(session);
+  return session;
+}
+
+// Google公式ボタンを描画する(GISはカスタムボタンからのID取得を許可していない)
+export async function renderGoogleButton(
+  container: HTMLElement,
+  onSuccess: () => void,
+  onError: (err: unknown) => void
+): Promise<void> {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) return;
+
+  await loadScript(GIS_SRC);
+  window.google!.accounts.id.initialize({
+    client_id: clientId,
+    callback: async (response) => {
+      try {
+        await signinWithIdentityToken('google', response.credential);
+        onSuccess();
+      } catch (err) {
+        onError(err);
+      }
+    },
+  });
+  window.google!.accounts.id.renderButton(container, {
+    theme: 'filled_black',
+    size: 'large',
+    width: 280,
+    text: 'signin_with',
+  });
+}
+
+export async function signInWithApple(): Promise<Session> {
+  const serviceId = import.meta.env.VITE_APPLE_SERVICE_ID;
+  if (!serviceId) {
+    throw new Error('Apple Sign-Inが設定されていません');
+  }
+
+  await loadScript(APPLE_SRC);
+  window.AppleID!.auth.init({
+    clientId: serviceId,
+    scope: '',
+    redirectURI: import.meta.env.VITE_APPLE_REDIRECT_URI ?? window.location.origin,
+    usePopup: true,
+  });
+  const { authorization } = await window.AppleID!.auth.signIn();
+  return await signinWithIdentityToken('apple', authorization.id_token);
+}

--- a/frontend/src/pages/FoodMasterPage.tsx
+++ b/frontend/src/pages/FoodMasterPage.tsx
@@ -15,11 +15,13 @@ interface FoodMaster {
   portionSize: number;
   portionUnit: string;
   usageCount: number;
+  isMine: boolean;
   createdBy?: string;
 }
 
 interface Props {
   onToast: (msg: Omit<ToastMessage, 'id'>) => void;
+  isAdmin: boolean;
 }
 
 const LIMIT = 30;
@@ -38,7 +40,7 @@ const emptyForm = {
 
 type FormData = typeof emptyForm;
 
-export default function FoodMasterPage({ onToast }: Props) {
+export default function FoodMasterPage({ onToast, isAdmin }: Props) {
   const [items, setItems] = useState<FoodMaster[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
@@ -111,6 +113,10 @@ export default function FoodMasterPage({ onToast }: Props) {
         const res = await client.api['food-masters'][':id'].$put({
           param: { id: editing.id },
         } as any, { init: { body: JSON.stringify(form), headers: { 'Content-Type': 'application/json' } } });
+        if (res.status === 403) {
+          onToast({ message: '他のユーザーが作成した食品は編集できません', type: 'error' });
+          return;
+        }
         if (!res.ok) throw new Error();
       } else {
         const id = crypto.randomUUID();
@@ -132,6 +138,11 @@ export default function FoodMasterPage({ onToast }: Props) {
     try {
       const client = createClient();
       const res = await client.api['food-masters'][':id'].$delete({ param: { id: item.id } });
+      if (res.status === 403) {
+        onToast({ message: '他のユーザーが作成した食品は削除できません', type: 'error' });
+        setDeleteTarget(null);
+        return;
+      }
       if (!res.ok) throw new Error();
       onToast({ message: '削除しました', type: 'success' });
       setDeleteTarget(null);
@@ -199,10 +210,12 @@ export default function FoodMasterPage({ onToast }: Props) {
                   <span className="px-1.5 py-0.5 text-xs" style={{ border: '1px solid #1a1a3e', color: '#6060a0' }}>{item.usageCount}</span>
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <button onClick={() => openEdit(item)} className="px-2 py-1 text-xs text-neon-cyan border border-neon-cyan/30 hover:border-neon-cyan hover:bg-neon-cyan/10 transition-all">EDIT</button>
-                    <button onClick={() => setDeleteTarget(item)} className="px-2 py-1 text-xs text-destructive border border-destructive/30 hover:border-destructive hover:bg-destructive/10 transition-all">DEL</button>
-                  </div>
+                  {(isAdmin || item.isMine) && (
+                    <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button onClick={() => openEdit(item)} className="px-2 py-1 text-xs text-neon-cyan border border-neon-cyan/30 hover:border-neon-cyan hover:bg-neon-cyan/10 transition-all">EDIT</button>
+                      <button onClick={() => setDeleteTarget(item)} className="px-2 py-1 text-xs text-destructive border border-destructive/30 hover:border-destructive hover:bg-destructive/10 transition-all">DEL</button>
+                    </div>
+                  )}
                 </td>
               </motion.tr>
             ))}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,12 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
+  // Google Cloud ConsoleのWebアプリ用OAuthクライアントID(未設定ならGoogleログイン非表示)
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
+  // Apple DeveloperのServices ID(未設定ならAppleログイン非表示)
+  readonly VITE_APPLE_SERVICE_ID?: string;
+  // AppleのReturn URL(省略時はwindow.location.origin)
+  readonly VITE_APPLE_REDIRECT_URI?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #104

## 背景

bitelog-admin.pages.dev は `ADMIN_API_KEY` のパスワード認証のみで、admin以外はWebからデータを見られなかった。バックエンドは既にマルチユーザー対応済み(iOSはApple/Google Sign-Inのidentity tokenで `userId` 単位にデータ分離)のため、Webにソーシャルログインを追加すれば既存のデータAPIがそのまま本人のデータを返せる。

## 変更内容

### Worker (cloudflare/)
- `verifyAppleToken` / `verifyGoogleToken` のaudience検証を許可リスト方式に変更(TDD、ユニットテスト12件)
- `POST /api/auth/signin` がWeb用の `GOOGLE_WEB_CLIENT_ID` / `APPLE_WEB_SERVICE_ID`(新規環境変数、未設定なら従来挙動)のaudも受理(統合テスト6件)
- Googleのissはhttpsあり/なし両形式を許容(Google公式仕様)

### Frontend (frontend/)
- ログイン画面にGoogle(GIS公式ボタン)とApple(popupモード)のサインインを追加。adminパスワードログインは折りたたみで維持
- `/api/auth/verify` の `userId` / `isAdmin` をセッションに保持し、サイドバーにロール表示
- 食品マスタのEDIT/DELボタンを `isAdmin || isMine` で出し分け、403時は理由を表示
- 401検知時はセッション破棄してログイン画面へ(JWT失効対策)
- CSPにGIS/Apple JSのソースを追加

## デプロイ前に必要な手動セットアップ

1. **Google Cloud Console**(iOSと同じプロジェクト): Webアプリ用OAuthクライアントIDを作成。承認済みJavaScript生成元に `https://bitelog-admin.pages.dev` と `http://localhost:5173`
2. **Apple Developer**: Services ID(例 `com.watahiki.BiteLog.web`)を作成しSign in with Appleを有効化。Domains/Return URLに `bitelog-admin.pages.dev` を登録
3. `wrangler secret put GOOGLE_WEB_CLIENT_ID` / `wrangler secret put APPLE_WEB_SERVICE_ID`
4. `frontend/.env` に `VITE_GOOGLE_CLIENT_ID` / `VITE_APPLE_SERVICE_ID` を設定してビルド(`.env.example` 参照)

## テスト

- `cd cloudflare && npm test` — 22件パス(新規18件含む)
- `cd frontend && bun run build` — tsc型チェック込みで成功
- 後方互換: Web用IDが未設定でもiOSアプリ・adminログインは従来どおり動作(テストでカバー)
- Appleログインはlocalhost不可のため、デプロイ後に本番で実機確認が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)