### PR TITLE
ログイン画面のAdmin Access(パスワード認証)を削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,7 @@ SweetPad: Generate Build Server Config
 - `frontend/`: React 19 + Vite + Tailwind CSS v4. Deployed to Cloudflare Pages (`bitelog-admin.pages.dev`)
 - `cloudflare/`: Hono on Cloudflare Workers + D1. Deployed to `bitelog-workers.v10acdict.workers.dev`
 - Type-safe API calls via Hono RPC: `cloudflare/src/index.ts` exports `AppType`, consumed by `frontend/src/lib/api.ts`
-- Admin auth: password is checked against the `ADMIN_API_KEY` Worker secret via `GET /api/auth/verify` (sent as `Authorization: Bearer` on every request)
-- User auth (social login): the login screen also offers Sign in with Apple / Google. The identity token goes to `POST /api/auth/signin`, which returns a 30-day session JWT tied to the same `userId` as the iOS app. Regular users see and edit only their own data (`isAdmin: false`)
+- Auth (social login only): the login screen offers Sign in with Apple / Google. The identity token goes to `POST /api/auth/signin`, which returns a 30-day session JWT tied to the same `userId` as the iOS app. Regular users see and edit only their own data (`isAdmin: false`); the user whose `userId` matches the `ADMIN_USER_ID` Worker secret gets `isAdmin: true`
   - Worker secrets: `GOOGLE_WEB_CLIENT_ID` (web OAuth client in the same Google Cloud project as iOS), `APPLE_WEB_SERVICE_ID` (Apple Services ID, e.g. `com.watahiki.BiteLog.web`)
   - Frontend build-time vars: `VITE_GOOGLE_CLIENT_ID`, `VITE_APPLE_SERVICE_ID` (see `frontend/.env.example`). Buttons are hidden when unset; Apple is also hidden on non-https origins (localhost) because Apple return URLs cannot point to localhost
 

--- a/cloudflare/src/middleware/auth.ts
+++ b/cloudflare/src/middleware/auth.ts
@@ -107,24 +107,6 @@ export async function verifyGoogleToken(
   return `google:${payload.sub}`;
 }
 
-// タイミング攻撃対策の定数時間比較
-async function constantTimeEqual(a: string, b: string): Promise<boolean> {
-  const enc = new TextEncoder();
-  const keyData = enc.encode('bitelog-admin-compare');
-  const key = await crypto.subtle.importKey(
-    'raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
-  );
-  const [sigA, sigB] = await Promise.all([
-    crypto.subtle.sign('HMAC', key, enc.encode(a)),
-    crypto.subtle.sign('HMAC', key, enc.encode(b)),
-  ]);
-  const viewA = new Uint8Array(sigA);
-  const viewB = new Uint8Array(sigB);
-  let diff = 0;
-  for (let i = 0; i < viewA.length; i++) diff |= viewA[i] ^ viewB[i];
-  return diff === 0;
-}
-
 // 認証ミドルウェア（全APIルートに適用）
 export const authMiddleware = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
   async (c, next) => {
@@ -133,14 +115,6 @@ export const authMiddleware = createMiddleware<{ Bindings: Bindings; Variables: 
       return c.json({ error: 'Unauthorized' }, 401);
     }
     const token = authHeader.slice(7);
-
-    // 管理画面用パスワード認証（期限なし）
-    if (c.env.ADMIN_API_KEY && await constantTimeEqual(token, c.env.ADMIN_API_KEY)) {
-      c.set('userId', c.env.ADMIN_USER_ID || 'admin');
-      c.set('isAdmin', true);
-      await next();
-      return;
-    }
 
     try {
       const userId = await verifySessionJwt(token, c.env.WORKER_JWT_SECRET);

--- a/cloudflare/src/routes/auth.test.ts
+++ b/cloudflare/src/routes/auth.test.ts
@@ -124,6 +124,15 @@ describe('POST /api/auth/signin', () => {
     expect(res.status).toBe(200);
   });
 
+  it('ADMIN_API_KEYと一致するパスワードをBearerに入れても401になる(パスワード認証は廃止)', async () => {
+    const res = await app.request(
+      '/api/auth/verify',
+      { headers: { Authorization: 'Bearer legacy-admin-password' } },
+      { ...TEST_ENV, ADMIN_API_KEY: 'legacy-admin-password' }
+    );
+    expect(res.status).toBe(401);
+  });
+
   it('signinで得たトークンで /api/auth/verify が通る', async () => {
     const signinRes = await signin(
       'google',

--- a/cloudflare/src/routes/auth.ts
+++ b/cloudflare/src/routes/auth.ts
@@ -47,7 +47,7 @@ auth.post('/signin', async (c) => {
 });
 
 // GET /api/auth/verify
-// 資格情報(管理キーまたはJWT)の有効性を確認する。管理画面のログイン検証に使う
+// セッションJWTの有効性を確認する。管理画面のログイン検証に使う
 auth.get('/verify', authMiddleware, (c) => {
   return c.json({ userId: c.get('userId'), isAdmin: c.get('isAdmin') });
 });

--- a/cloudflare/src/types.ts
+++ b/cloudflare/src/types.ts
@@ -1,7 +1,6 @@
 export type Bindings = {
   DB: D1Database;
   WORKER_JWT_SECRET: string;
-  ADMIN_API_KEY: string;
   ADMIN_USER_ID: string;
   GOOGLE_CLIENT_ID: string;
   // Web管理画面のソーシャルログイン用（未設定の場合はWebからのサインイン不可）

--- a/cloudflare/vitest.config.mts
+++ b/cloudflare/vitest.config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
     cloudflareTest({
       wrangler: { configPath: './wrangler.toml' },
       miniflare: {
-        vars: { WORKER_JWT_SECRET: 'test-secret' },
+        bindings: { WORKER_JWT_SECRET: 'dev-and-test-secret' },
       },
     }),
   ],

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -8,9 +8,8 @@ binding = "DB"
 database_name = "bitelog"
 database_id = "cf39b710-956c-4f27-ae1a-6dbf7a6a0fef"
 
-[vars]
-# 本番では wrangler secret put WORKER_JWT_SECRET で上書きすること
-WORKER_JWT_SECRET = "dev-and-test-secret"
+# WORKER_JWT_SECRET は wrangler secret put で設定する（平文varにすると同名secretを作れない）
+# ローカル開発・テスト用の値は .dev.vars / vitest.config.mts で渡す
 
 # Web管理画面のソーシャルログインを有効にするには、以下も wrangler secret put で設定する
 # - GOOGLE_WEB_CLIENT_ID: Google Cloud ConsoleのWebアプリ用OAuthクライアントID（iOSと同じプロジェクト）

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -2,4 +2,4 @@
   Content-Security-Policy: default-src 'self'; script-src 'self' https://accounts.google.com/gsi/client https://appleid.cdn-apple.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com/gsi/style; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://bitelog-workers.v10acdict.workers.dev https://accounts.google.com/gsi/; frame-src https://accounts.google.com/gsi/ https://appleid.apple.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
-  Referrer-Policy: same-origin
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/frontend/src/components/SetupModal.tsx
+++ b/frontend/src/components/SetupModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'motion/react';
-import { setSession, API_URL } from '@/lib/auth';
 import {
   isAppleLoginConfigured,
   isGoogleLoginConfigured,
@@ -13,10 +12,7 @@ interface Props {
 }
 
 export default function SetupModal({ onAuthenticated }: Props) {
-  const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [showAdminForm, setShowAdminForm] = useState(false);
   const googleButtonRef = useRef<HTMLDivElement>(null);
 
   const googleEnabled = isGoogleLoginConfigured();
@@ -42,31 +38,6 @@ export default function SetupModal({ onAuthenticated }: Props) {
       if (err instanceof Error && err.message.includes('サインイン')) {
         setError(err.message);
       }
-    }
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError('');
-    setLoading(true);
-
-    try {
-      const res = await fetch(`${API_URL}/api/auth/verify`, {
-        headers: { Authorization: `Bearer ${password}` },
-      });
-
-      if (!res.ok) {
-        setError('認証失敗: パスワードを確認してください');
-        setLoading(false);
-        return;
-      }
-
-      const { userId, isAdmin } = (await res.json()) as { userId: string; isAdmin: boolean };
-      setSession({ token: password, userId, isAdmin });
-      onAuthenticated();
-    } catch {
-      setError('接続エラー: APIサーバーに到達できません');
-      setLoading(false);
     }
   }
 
@@ -99,8 +70,8 @@ export default function SetupModal({ onAuthenticated }: Props) {
             </div>
           </div>
 
-          {socialEnabled && (
-            <div className="space-y-3 mb-6">
+          {socialEnabled ? (
+            <div className="space-y-3">
               {googleEnabled && (
                 <div ref={googleButtonRef} className="flex justify-center" />
               )}
@@ -118,59 +89,16 @@ export default function SetupModal({ onAuthenticated }: Props) {
                 </motion.button>
               )}
             </div>
+          ) : (
+            <p className="text-xs text-muted-foreground tracking-wide">
+              ソーシャルログインが設定されていません。VITE_GOOGLE_CLIENT_ID または
+              VITE_APPLE_SERVICE_ID を設定してください。
+            </p>
           )}
 
           {error && (
-            <p className="text-xs text-destructive tracking-wide mb-4">{error}</p>
+            <p className="text-xs text-destructive tracking-wide mt-4">{error}</p>
           )}
-
-          {/* 管理者用パスワードログイン(折りたたみ) */}
-          <div className={socialEnabled ? 'border-t border-border-dim pt-4' : ''}>
-            {socialEnabled && (
-              <button
-                type="button"
-                onClick={() => setShowAdminForm((v) => !v)}
-                className="w-full text-left text-xs text-muted-foreground tracking-widest uppercase hover:text-neon-cyan transition-colors"
-              >
-                {showAdminForm ? '▾' : '▸'} Admin Access
-              </button>
-            )}
-
-            {(!socialEnabled || showAdminForm) && (
-              <form onSubmit={handleSubmit} className="space-y-4 mt-4">
-                <div>
-                  <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">
-                    Password
-                  </label>
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="w-full bg-bg-card border border-border-dim px-3 py-2 text-sm text-foreground focus:outline-none focus:border-neon-cyan transition-colors"
-                    style={{ fontFamily: 'inherit' }}
-                    placeholder="••••••••"
-                    autoFocus
-                  />
-                </div>
-
-                <motion.button
-                  type="submit"
-                  disabled={loading || !password}
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  className="w-full py-2 text-sm font-bold tracking-widest uppercase transition-all disabled:opacity-40"
-                  style={{
-                    background: loading ? 'transparent' : 'rgba(0,229,255,0.1)',
-                    border: '1px solid #00e5ff',
-                    color: '#00e5ff',
-                    boxShadow: loading ? 'none' : '0 0 15px rgba(0,229,255,0.3)',
-                  }}
-                >
-                  {loading ? 'CONNECTING...' : 'LOGIN'}
-                </motion.button>
-              </form>
-            )}
-          </div>
         </div>
       </motion.div>
     </div>

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,4 @@
-const TOKEN_KEY = 'bitelog_admin_token';
+const TOKEN_KEY = 'bitelog_session_token';
 const USER_KEY = 'bitelog_session_user';
 
 export const API_URL =


### PR DESCRIPTION
Closes #107

## 背景

`ADMIN_API_KEY` による固定パスワード認証は、Webにソーシャルログインが無かった頃に「JWTを30日ごとに手貼り付けする」運用を回避するために導入したもの(edaf5c2)。#105 でWebにApple/Googleサインインが入り、adminは `ADMIN_USER_ID` と一致する自分のアカウントでログインすれば `isAdmin: true` が付与されるようになったため、役目を終えた。

## 変更内容

- **Worker**: `authMiddleware` の `ADMIN_API_KEY` 分岐と `constantTimeEqual` を削除し、JWT認証のみに一本化。`Bindings` から `ADMIN_API_KEY` を削除
- **回帰テスト**: ADMIN_API_KEYと一致するパスワードをBearerに入れても401になることを確認
- **Frontend**: ログイン画面のAdmin Accessトグルとパスワードフォームを削除。ソーシャルログイン未設定時は設定方法の案内を表示
- **CLAUDE.md**: 認証の説明をソーシャルログインのみの構成に更新

## マージ後の作業(手動)

- [x] `cd cloudflare && npx wrangler secret delete ADMIN_API_KEY` (実施済み)
- [x] ローカルの `cloudflare/.dev.vars` から `ADMIN_API_KEY` を削除 (実施済み)
- [x] Worker → Pages の順にデプロイ (実施済み。あわせてWORKER_JWT_SECRETを平文varからsecretに移行しローテート済み)

## テスト

- `cd cloudflare && npm test` — 23件パス(回帰テスト1件追加)
- `cd frontend && bun run build` — tsc型チェック込みで成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## 追加修正

- `_headers` の `Referrer-Policy: same-origin` が原因で、本番のGoogleログインボタンが「The given origin is not allowed for the given client ID」で機能していなかった(承認済みJavaScript生成元には登録済み)。クロスオリジンにorigin情報が送られずGSIが埋め込み元を検証できないため。`strict-origin-when-cross-origin` に変更し、本番でGoogleのアカウント選択画面が開くことを確認済み
