### PR TITLE
fix: Meal Logの栄養価集計の桁数異常を修正

### DIFF
--- a/frontend/src/pages/MealLogPage.tsx
+++ b/frontend/src/pages/MealLogPage.tsx
@@ -11,6 +11,7 @@ interface NutritionSource {
   fat: number;
   netCarbs: number;
   dietaryFiber: number;
+  portionSize: number;
 }
 
 interface LogItem {
@@ -43,12 +44,12 @@ function today() {
 function getNutrition(item: LogItem) {
   const src = item.isMasterDeleted ? item.nutritionSnapshot : (item.foodMaster ?? item.nutritionSnapshot);
   if (!src) return { calories: 0, protein: 0, fat: 0, netCarbs: 0, name: '—', brand: '' };
-  const s = item.numberOfServings;
+  const ratio = src.portionSize > 0 ? item.numberOfServings / src.portionSize : 0;
   return {
-    calories: Math.round(src.calories * s),
-    protein: Math.round(src.protein * s * 10) / 10,
-    fat: Math.round(src.fat * s * 10) / 10,
-    netCarbs: Math.round(src.netCarbs * s * 10) / 10,
+    calories: Math.round(src.calories * ratio),
+    protein: Math.round(src.protein * ratio * 10) / 10,
+    fat: Math.round(src.fat * ratio * 10) / 10,
+    netCarbs: Math.round(src.netCarbs * ratio * 10) / 10,
     name: src.productName,
     brand: src.brandName,
   };


### PR DESCRIPTION
## Summary
- web管理画面のMeal Logページで、栄養価の合計・各行の値がportionSizeで割られておらず、実際の値の約100倍(portionSizeが100の場合)になっていた問題を修正
- `getNutrition` で `numberOfServings / portionSize` の比率を栄養値に乗算するように変更（iOSアプリの `NutritionSnapshot.scaled(by:)` と同じ計算）
- `NutritionSource` 型に `portionSize` を追加

## Test plan
- [x] `cd cloudflare && npm test` (23 tests passed)
- [x] `cd frontend && bun run build` (tsc + vite build成功)
- [x] ローカルWorker(wrangler dev) + ローカルD1にテストデータ(portionSize=100, numberOfServings=150のfoodMaster / portionSize=50, numberOfServings=50のnutritionSnapshot)を投入し、Playwrightでブラウザ確認
  - 修正前ロジックなら calories=30000 になるところ、修正後は 200kcal×1.5=300kcal と正しく表示
  - nutritionSnapshot(isMasterDeleted)経路でも 80kcal×1.0=80kcal と正しく表示
  - 合計表示も 380kcal / 19g / 9.5g / 40g と正しく集計

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)