### PR TITLE
AI食事解析のプロンプト・API呼び出しを改善する

### DIFF
--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -223,8 +223,8 @@ final class APIClient {
 
   // MARK: - AI
 
-  func analyzeFoodImage(imageBase64: String) async throws -> AIAnalyzeResponse {
-    return try await request(path: "/api/ai/analyze-food", method: "POST", body: AIAnalyzeRequest(imageBase64: imageBase64))
+  func analyzeFoodImage(imageBase64: String, note: String? = nil) async throws -> AIAnalyzeResponse {
+    return try await request(path: "/api/ai/analyze-food", method: "POST", body: AIAnalyzeRequest(imageBase64: imageBase64, note: note))
   }
 
   // MARK: - Auth

--- a/BiteLog/Network/DTOs.swift
+++ b/BiteLog/Network/DTOs.swift
@@ -177,6 +177,7 @@ extension NutritionSnapshot {
 
 struct AIAnalyzeRequest: Codable {
   var imageBase64: String
+  var note: String?
 }
 
 struct AIAnalyzeResponse: Codable {

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "AI Food Analysis" = "AI Food Analysis";
 "Reselect" = "Reselect";
 "Analyze" = "Analyze";
+"Note (optional)" = "Note (optional)";
+"e.g. Brand/product name, amount eaten, etc." = "e.g. Brand/product name, amount eaten, etc.";
 
 // AI Analysis
 "Analyzing food..." = "Analyzing food...";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -165,6 +165,8 @@
 "AI Food Analysis" = "AI料理分析";
 "Reselect" = "再選択";
 "Analyze" = "分析する";
+"Note (optional)" = "補足メモ(任意)";
+"e.g. Brand/product name, amount eaten, etc." = "例: 店名・商品名、食べた量など";
 
 // AI Analysis
 "Analyzing food..." = "料理を分析中...";

--- a/BiteLog/Utilities/AIFoodAnalyzer.swift
+++ b/BiteLog/Utilities/AIFoodAnalyzer.swift
@@ -25,7 +25,7 @@ class AIFoodAnalyzer {
   }
 
   // 写真から料理を分析
-  func analyzeFood(image: UIImage) async throws -> FoodAnalysisResult {
+  func analyzeFood(image: UIImage, note: String? = nil) async throws -> FoodAnalysisResult {
     let available = await MainActor.run { AuthManager.shared.isSignedIn }
     guard available else {
       throw AnalysisError.notAuthenticated
@@ -40,7 +40,7 @@ class AIFoodAnalyzer {
     let base64Image = imageData.base64EncodedString()
 
     do {
-      let response = try await APIClient.shared.analyzeFoodImage(imageBase64: base64Image)
+      let response = try await APIClient.shared.analyzeFoodImage(imageBase64: base64Image, note: note)
       return FoodAnalysisResult(
         productName: response.productName,
         calories: response.calories,

--- a/BiteLog/Views/AddItemView.swift
+++ b/BiteLog/Views/AddItemView.swift
@@ -68,7 +68,7 @@ struct AddItemView: View {
         if !isDataLoaded { Task { await loadFoodMasters() } }
       }
       .sheet(isPresented: $showingPhotoPicker) {
-        PhotoPickerView(selectedImage: $selectedImage) { image in analyzeImage(image) }
+        PhotoPickerView(selectedImage: $selectedImage) { image, note in analyzeImage(image, note: note) }
       }
       .sheet(isPresented: $showingAnalysisResult) {
         if let result = analysisResult, let image = selectedImage {
@@ -103,11 +103,11 @@ struct AddItemView: View {
     }
   }
 
-  private func analyzeImage(_ image: UIImage) {
+  private func analyzeImage(_ image: UIImage, note: String?) {
     Task {
       await MainActor.run { isAnalyzing = true; showingPhotoPicker = false }
       do {
-        let result = try await AIFoodAnalyzer.shared.analyzeFood(image: image)
+        let result = try await AIFoodAnalyzer.shared.analyzeFood(image: image, note: note)
         await MainActor.run { isAnalyzing = false; analysisResult = result; showingAnalysisResult = true }
       } catch {
         await MainActor.run { isAnalyzing = false; analysisError = error.localizedDescription }

--- a/BiteLog/Views/PhotoPickerView.swift
+++ b/BiteLog/Views/PhotoPickerView.swift
@@ -5,11 +5,12 @@ import PhotosUI
 struct PhotoPickerView: View {
   @Environment(\.dismiss) var dismiss
   @Binding var selectedImage: UIImage?
-  var onAnalyze: (UIImage) -> Void
-  
+  var onAnalyze: (UIImage, String?) -> Void
+
   @State private var showingImagePicker = false
   @State private var showingCamera = false
   @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
+  @State private var note: String = ""
   
   var body: some View {
     NavigationStack {
@@ -23,10 +24,23 @@ struct PhotoPickerView: View {
               .frame(maxHeight: 400)
               .cornerRadius(12)
               .shadow(radius: 5)
-            
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text(NSLocalizedString("Note (optional)", comment: "Label"))
+                .font(.caption)
+                .foregroundColor(.secondary)
+              TextField(
+                NSLocalizedString("e.g. Brand/product name, amount eaten, etc.", comment: "Placeholder"),
+                text: $note
+              )
+              .textFieldStyle(.roundedBorder)
+            }
+            .padding(.horizontal)
+
             HStack(spacing: 16) {
               Button {
                 selectedImage = nil
+                note = ""
               } label: {
                 Label(NSLocalizedString("Reselect", comment: "Button title"), systemImage: "arrow.clockwise")
                   .frame(maxWidth: .infinity)
@@ -35,9 +49,10 @@ struct PhotoPickerView: View {
                   .foregroundColor(.primary)
                   .cornerRadius(10)
               }
-              
+
               Button {
-                onAnalyze(image)
+                let trimmedNote = note.trimmingCharacters(in: .whitespacesAndNewlines)
+                onAnalyze(image, trimmedNote.isEmpty ? nil : trimmedNote)
               } label: {
                 Label(NSLocalizedString("Analyze", comment: "Button title"), systemImage: "sparkles")
                   .frame(maxWidth: .infinity)

--- a/cloudflare/src/routes/aiAnalyze.test.ts
+++ b/cloudflare/src/routes/aiAnalyze.test.ts
@@ -1,0 +1,182 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import app from '../index';
+import { issueSessionJwt } from '../middleware/auth';
+
+const TEST_SECRET = 'ai-analyze-test-secret';
+const TEST_ENV = {
+  WORKER_JWT_SECRET: TEST_SECRET,
+  OPENAI_API_KEY: 'test-openai-key',
+};
+
+const VALID_ANALYSIS = {
+  productName: 'おにぎり',
+  calories: 180,
+  protein: 4,
+  fat: 1,
+  sugar: 38,
+  dietaryFiber: 1,
+  portion: 1,
+  portionUnit: '個',
+  confidence: 'medium',
+};
+
+type FetchHandler = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+let openaiHandler: FetchHandler = async () =>
+  Response.json({ choices: [{ message: { content: JSON.stringify(VALID_ANALYSIS) } }] });
+
+let lastOpenaiRequestBody: unknown;
+
+beforeAll(() => {
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input.toString();
+    if (url === 'https://api.openai.com/v1/chat/completions') {
+      lastOpenaiRequestBody = init?.body ? JSON.parse(init.body as string) : undefined;
+      return await openaiHandler(input, init);
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  openaiHandler = async () =>
+    Response.json({ choices: [{ message: { content: JSON.stringify(VALID_ANALYSIS) } }] });
+  lastOpenaiRequestBody = undefined;
+});
+
+async function authHeader(): Promise<Record<string, string>> {
+  const token = await issueSessionJwt('test-user', TEST_SECRET);
+  return { Authorization: `Bearer ${token}` };
+}
+
+function analyzeFood(body: object, headers: Record<string, string>) {
+  return app.request(
+    '/api/ai/analyze-food',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    },
+    TEST_ENV
+  );
+}
+
+describe('POST /api/ai/analyze-food', () => {
+  it('imageBase64がない場合は400', async () => {
+    const res = await analyzeFood({}, await authHeader());
+    expect(res.status).toBe(400);
+  });
+
+  it('未認証の場合は401', async () => {
+    const res = await analyzeFood({ imageBase64: 'dummy' }, {});
+    expect(res.status).toBe(401);
+  });
+
+  it('AIの解析結果をレスポンス形式にマッピングする', async () => {
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({
+      productName: 'おにぎり',
+      calories: 180,
+      protein: 4,
+      fat: 1,
+      netCarbs: 38,
+      dietaryFiber: 1,
+      portionAmount: 1,
+      portionUnit: '個',
+      confidence: 'medium',
+    });
+  });
+
+  it('OpenAIへのリクエストでStructured OutputsとminimalなreasoningEffortを指定する', async () => {
+    await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+
+    const reqBody = lastOpenaiRequestBody as {
+      model: string;
+      reasoning_effort: string;
+      response_format: { type: string; json_schema: { strict: boolean } };
+    };
+    expect(reqBody.model).toBe('gpt-5-mini');
+    expect(reqBody.reasoning_effort).toBe('minimal');
+    expect(reqBody.response_format.type).toBe('json_schema');
+    expect(reqBody.response_format.json_schema.strict).toBe(true);
+  });
+
+  it('noteを指定すると画像と一緒にユーザーの補足情報を送信する', async () => {
+    await analyzeFood({ imageBase64: 'dummy', note: 'マクドナルドのビッグマック' }, await authHeader());
+
+    const reqBody = lastOpenaiRequestBody as {
+      messages: Array<{ content: Array<{ type: string; text?: string }> }>;
+    };
+    const textParts = reqBody.messages[0].content.filter((part) => part.type === 'text');
+    expect(textParts.some((part) => part.text?.includes('マクドナルドのビッグマック'))).toBe(true);
+  });
+
+  it('noteが空文字の場合は補足テキストを追加しない', async () => {
+    await analyzeFood({ imageBase64: 'dummy', note: '   ' }, await authHeader());
+
+    const reqBody = lastOpenaiRequestBody as {
+      messages: Array<{ content: Array<{ type: string; text?: string }> }>;
+    };
+    const textParts = reqBody.messages[0].content.filter((part) => part.type === 'text');
+    expect(textParts).toHaveLength(1);
+  });
+
+  it('OpenAIが429を返した場合はレート制限エラーになる', async () => {
+    openaiHandler = async () => new Response('rate limited', { status: 429 });
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(429);
+  });
+
+  it('OpenAIが401を返した場合はAI設定エラーになる', async () => {
+    openaiHandler = async () => new Response('unauthorized', { status: 401 });
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(502);
+  });
+
+  it('OpenAIがその他のエラーを返した場合は500になる', async () => {
+    openaiHandler = async () => new Response('error', { status: 500 });
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(500);
+  });
+
+  it('OpenAI呼び出し自体が失敗した場合は500になる', async () => {
+    openaiHandler = async () => {
+      throw new Error('network error');
+    };
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(500);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe('Failed to reach OpenAI API');
+  });
+
+  it('contentが空の場合は500になる', async () => {
+    openaiHandler = async () => Response.json({ choices: [{ message: { content: '' } }] });
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(500);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe('No content from AI');
+  });
+
+  it('contentが不正なJSONの場合は500になる', async () => {
+    openaiHandler = async () =>
+      Response.json({ choices: [{ message: { content: 'not json' } }] });
+
+    const res = await analyzeFood({ imageBase64: 'dummy' }, await authHeader());
+    expect(res.status).toBe(500);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe('Failed to parse AI response');
+  });
+});

--- a/cloudflare/src/routes/aiAnalyze.ts
+++ b/cloudflare/src/routes/aiAnalyze.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from '../middleware/auth';
 const aiAnalyze = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 aiAnalyze.use('*', authMiddleware);
 
-const PROMPT = `Analyze this image and return nutrition information in JSON format.
+const PROMPT = `Analyze this image and return nutrition information for the food shown.
 
 IMPORTANT - Nutrition Label Reading:
 If the image contains a nutrition facts label (package/product label), prioritize reading the text:
@@ -18,31 +18,94 @@ If the image contains a nutrition facts label (package/product label), prioritiz
 If "糖質" and "食物繊維" are both listed, use those values directly. If only "炭水化物" is listed, set sugar = 炭水化物 and dietaryFiber = 0.
 If a nutrition label is present, set confidence to "high".
 
-Return ONLY this JSON format (no other text):
-{
-  "productName": "Product or dish name in Japanese",
-  "calories": number in kcal,
-  "protein": number in grams,
-  "fat": number in grams,
-  "sugar": number in grams,
-  "dietaryFiber": number in grams,
-  "portion": portion amount (number),
-  "portionUnit": "unit (e.g., g, ml, 個, 人前)",
-  "confidence": "high" or "medium" or "low"
-}
+IMPORTANT - Portion:
+"portion"/"portionUnit" describe BOTH the basis for all returned nutrition values AND the amount the user is about to log as eaten right now - they refer to the same quantity.
+- If a nutrition label shows "per 100g" values but the visible package/container holds a different total amount, scale ALL nutrition values up from the label to the whole package, and set portion to the package's total size (not 100) with its unit.
+- If the photo shows a dish or serving without a label, set portion/portionUnit to a sensible amount for what is shown (e.g., 1 "人前", or an estimated weight in g) and provide nutrition values for that whole amount.
+- For multiple items in one photo, sum the totals into a single result and set portion/portionUnit to describe the combined amount.
 
-Rules:
-- If nutrition label exists, read and use those exact values
-- For food photos without labels, estimate typical serving size
-- For multiple items, sum the total values
-- Return JSON only, no explanations`;
+If a user note is provided, use it to identify the product/dish, resolve visual ambiguity (e.g., regular vs. sugar-free version), and account for any amount actually consumed (e.g., "half eaten").`;
+
+const RESPONSE_SCHEMA = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'food_nutrition_analysis',
+    strict: true,
+    schema: {
+      type: 'object',
+      properties: {
+        productName: {
+          type: 'string',
+          description: 'Product or dish name in Japanese',
+        },
+        calories: {
+          type: 'number',
+          description: 'Total calories in kcal for the "portion" amount',
+        },
+        protein: {
+          type: 'number',
+          description: 'Protein in grams for the "portion" amount',
+        },
+        fat: {
+          type: 'number',
+          description: 'Fat in grams for the "portion" amount',
+        },
+        sugar: {
+          type: 'number',
+          description: '糖質 (sugar/net carbs) in grams for the "portion" amount',
+        },
+        dietaryFiber: {
+          type: 'number',
+          description: '食物繊維 in grams for the "portion" amount',
+        },
+        portion: {
+          type: 'number',
+          description: 'The amount that the nutrition values represent and that the user is logging now',
+        },
+        portionUnit: {
+          type: 'string',
+          description: 'Unit for portion, e.g. g, ml, 個, 人前',
+        },
+        confidence: {
+          type: 'string',
+          enum: ['high', 'medium', 'low'],
+        },
+      },
+      required: [
+        'productName',
+        'calories',
+        'protein',
+        'fat',
+        'sugar',
+        'dietaryFiber',
+        'portion',
+        'portionUnit',
+        'confidence',
+      ],
+      additionalProperties: false,
+    },
+  },
+};
 
 aiAnalyze.post('/analyze-food', async (c) => {
-  const body = await c.req.json<{ imageBase64?: string }>();
+  const body = await c.req.json<{ imageBase64?: string; note?: string }>();
 
   if (!body.imageBase64 || typeof body.imageBase64 !== 'string') {
     return c.json({ error: 'imageBase64 is required' }, 400);
   }
+
+  const messageContent: Array<
+    { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
+  > = [{ type: 'text', text: PROMPT }];
+
+  if (typeof body.note === 'string' && body.note.trim()) {
+    messageContent.push({ type: 'text', text: `User note: ${body.note.trim()}` });
+  }
+
+  messageContent.push({
+    type: 'image_url',
+    image_url: { url: `data:image/jpeg;base64,${body.imageBase64}` },
+  });
 
   let openaiRes: Response;
   try {
@@ -54,18 +117,9 @@ aiAnalyze.post('/analyze-food', async (c) => {
       },
       body: JSON.stringify({
         model: 'gpt-5-mini',
-        messages: [
-          {
-            role: 'user',
-            content: [
-              { type: 'text', text: PROMPT },
-              {
-                type: 'image_url',
-                image_url: { url: `data:image/jpeg;base64,${body.imageBase64}` },
-              },
-            ],
-          },
-        ],
+        reasoning_effort: 'minimal',
+        messages: [{ role: 'user', content: messageContent }],
+        response_format: RESPONSE_SCHEMA,
         max_completion_tokens: 4096,
       }),
     });
@@ -88,8 +142,10 @@ aiAnalyze.post('/analyze-food', async (c) => {
     return c.json({ error: 'No content from AI' }, 500);
   }
 
-  const parsed = extractAndParseJSON(content);
-  if (!parsed) {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(content) as Record<string, unknown>;
+  } catch {
     return c.json({ error: 'Failed to parse AI response' }, 500);
   }
 
@@ -105,20 +161,5 @@ aiAnalyze.post('/analyze-food', async (c) => {
     productName: (parsed['productName'] as string) ?? '不明な料理',
   });
 });
-
-function extractAndParseJSON(text: string): Record<string, unknown> | null {
-  const fenceMatch = text.match(/```json\s*([\s\S]*?)```/);
-  const candidate = fenceMatch ? fenceMatch[1].trim() : text.trim();
-
-  const start = candidate.indexOf('{');
-  const end = candidate.lastIndexOf('}');
-  if (start === -1 || end === -1) return null;
-
-  try {
-    return JSON.parse(candidate.slice(start, end + 1)) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
 
 export default aiAnalyze;


### PR DESCRIPTION
## Summary
- `response_format: json_schema (strict)` でAIの応答形式をスキーマ強制し、フリーテキストからのJSON抽出ロジック（フェンス/波括弧パース）を撤廃
- `reasoning_effort: 'minimal'` を指定し、gpt-5-miniの推論トークン消費による応答切れ・パース失敗のリスクを低減
- プロンプトの "portion"/"portionUnit" の意味を明確化（栄養値の基準量 = 今回ログとして記録する量、であることを明示し、ラベルが100gあたりの値でもパッケージ全体に合わせてスケールするよう指示)
- 写真と一緒にユーザーが補足メモ（商品名・食べた量など）を入力できるUIを追加し、AIプロンプトに反映して解析精度の向上に活用

## Details
- `cloudflare/src/routes/aiAnalyze.ts`: プロンプト・レスポンススキーマ・リクエストボディを更新、`extractAndParseJSON` を削除して `JSON.parse` に統一
- `cloudflare/src/routes/aiAnalyze.test.ts`: 新規追加。認証・バリデーション・レスポンスマッピング・`reasoning_effort`/`response_format`送信・補足メモ反映・各種エラーハンドリングをカバー
- iOS: `AIAnalyzeRequest`/`APIClient`/`AIFoodAnalyzer` に `note` パラメータを追加、`PhotoPickerView` に補足メモ入力フィールドを追加し `AddItemView` から伝播
- ローカライズ文字列（ja/en）を追加

Closes #110

## Test plan
- [x] `cd cloudflare && npx vitest run` で全テスト通過 (35/35)
- [ ] iOSアプリをビルドし、写真選択→補足メモ入力→AI分析→結果保存の一連のフローを実機/シミュレータで確認