### PR TITLE
feat: 日々のログを振り返る統計タブを追加

### DIFF
--- a/BiteLog/Network/APIClient.swift
+++ b/BiteLog/Network/APIClient.swift
@@ -186,6 +186,12 @@ final class APIClient {
     return resp.items
   }
 
+  /// 期間範囲（"yyyy-MM-dd"、両端含む）の LogItem を取得（統計用）
+  func fetchLogItems(from: String, to: String) async throws -> [LogItemDTO] {
+    let resp: LogItemListResponse = try await request(path: "/api/log-items?from=\(from)&to=\(to)")
+    return resp.items
+  }
+
   func createLogItem(_ dto: LogItemCreateDTO) async throws -> LogItemDTO {
     return try await request(path: "/api/log-items", method: "POST", body: dto)
   }

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -190,3 +190,19 @@
 "Macronutrients" = "Macronutrients";
 "Calories are automatically calculated" = "Calories are automatically calculated";
 "Reset to Defaults" = "Reset to Defaults";
+
+/* Statistics */
+"Statistics" = "Statistics";
+"Week" = "Week";
+"Month" = "Month";
+"Custom" = "Custom";
+"From" = "From";
+"To" = "To";
+"Trend" = "Trend";
+"Daily Average" = "Daily Average";
+"Days on Target" = "Days on Target";
+"%d / %d days" = "%d / %d days";
+"PFC Balance" = "PFC Balance";
+"By Meal Type" = "By Meal Type";
+"No records in this period" = "No records in this period";
+"Carbs (Sugar + Fiber)" = "Carbs (Sugar + Fiber)";

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -206,3 +206,4 @@
 "By Meal Type" = "By Meal Type";
 "No records in this period" = "No records in this period";
 "Carbs (Sugar + Fiber)" = "Carbs (Sugar + Fiber)";
+"Total" = "Total";

--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -207,3 +207,4 @@
 "No records in this period" = "No records in this period";
 "Carbs (Sugar + Fiber)" = "Carbs (Sugar + Fiber)";
 "Total" = "Total";
+"Year" = "Year";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -221,3 +221,4 @@
 "By Meal Type" = "食事タイプ別";
 "No records in this period" = "この期間の記録はありません";
 "Total" = "合計";
+"Year" = "年";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -205,3 +205,18 @@
 "Calories are automatically calculated" = "カロリーは自動計算されます";
 "Reset to Defaults" = "デフォルトに戻す";
 
+
+/* Statistics */
+"Statistics" = "統計";
+"Week" = "週";
+"Month" = "月";
+"Custom" = "カスタム";
+"From" = "開始";
+"To" = "終了";
+"Trend" = "推移";
+"Daily Average" = "1日平均";
+"Days on Target" = "目標達成日数";
+"%d / %d days" = "%d / %d 日";
+"PFC Balance" = "PFCバランス";
+"By Meal Type" = "食事タイプ別";
+"No records in this period" = "この期間の記録はありません";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -220,3 +220,4 @@
 "PFC Balance" = "PFCバランス";
 "By Meal Type" = "食事タイプ別";
 "No records in this period" = "この期間の記録はありません";
+"Total" = "合計";

--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -106,6 +106,13 @@ struct ContentView: View {
       }
       .opacity(selectedTab == 1 ? 1 : 0)
       .zIndex(selectedTab == 1 ? 1 : 0)
+
+      // 統計タブ
+      NavigationStack {
+        StatisticsView()
+      }
+      .opacity(selectedTab == 2 ? 1 : 0)
+      .zIndex(selectedTab == 2 ? 1 : 0)
       }
       .clipped()
 
@@ -139,6 +146,20 @@ struct ContentView: View {
           }
           .frame(maxWidth: .infinity)
           .foregroundColor(selectedTab == 1 ? .blue : .gray)
+        }
+
+        // 統計タブ
+        Button(action: {
+          selectedTab = 2
+        }) {
+          VStack(spacing: 4) {
+            Image(systemName: "chart.bar.xaxis")
+              .font(.system(size: 24))
+            Text(NSLocalizedString("Statistics", comment: "Statistics tab"))
+              .font(.caption)
+          }
+          .frame(maxWidth: .infinity)
+          .foregroundColor(selectedTab == 2 ? .blue : .gray)
         }
       }
       .padding(.vertical, 8)

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -440,6 +440,33 @@ struct StatisticsView: View {
 
     statsCard(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
       VStack(spacing: 14) {
+        // 期間全体の合計
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 8) {
+            Image(systemName: "sum")
+              .font(.system(size: 14))
+              .foregroundColor(.primary)
+              .frame(width: 20)
+            Text(NSLocalizedString("Total", comment: "Period total"))
+              .font(.subheadline.weight(.bold))
+            Spacer()
+            Text("\(NutritionFormatter.formatNutrition(periodTotal.calories))")
+              .font(.subheadline.weight(.bold))
+              + Text(" kcal")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+
+          HStack(spacing: 6) {
+            MacroChip(label: "P", value: periodTotal.protein, color: .blue)
+            MacroChip(label: "F", value: periodTotal.fat, color: .yellow)
+            MacroChip(label: "S", value: periodTotal.netCarbs, color: .green)
+            MacroChip(label: "Fb", value: periodTotal.dietaryFiber, color: .brown)
+          }
+        }
+
+        Divider()
+
         ForEach(totals, id: \.type) { entry in
           VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -59,6 +59,15 @@ struct StatsDayPoint: Identifiable {
   var id: Date { date }
 }
 
+// MARK: - 表示中ウィンドウの集計結果（1パスでまとめて算出）
+
+struct VisibleStats {
+  var total: NutritionValues = .zero
+  var recordedDays = 0
+  var daysOnTarget = 0
+  var mealTotals: [MealType: NutritionValues] = [:]
+}
+
 // MARK: - 統計画面
 
 struct StatisticsView: View {
@@ -71,7 +80,11 @@ struct StatisticsView: View {
   @State private var customEnd = Date()
   @State private var trendMetric: TrendMetric = .calories
 
-  @State private var items: [LogItemDTO] = []
+  // 集計結果をキャッシュ（生のログは保持せず畳み込む。5万件規模でも軽量）
+  @State private var dayTotals: [String: NutritionValues] = [:]
+  @State private var dayMealTotals: [String: [MealType: NutritionValues]] = [:]
+  @State private var monthTotals: [Date: NutritionValues] = [:]
+  @State private var trendPoints: [StatsDayPoint] = []
   /// 取得済みの最も古い日。スクロールで端に近づくと過去へ伸ばす
   @State private var loadedStart = Calendar.current.date(byAdding: .day, value: -730, to: Date())!
   @State private var isLoading = false
@@ -85,6 +98,8 @@ struct StatisticsView: View {
   private let initialSpanDays = 730
   /// 端に達したとき追加で遡る日数（1年ずつ）
   private let chunkDays = 365
+  /// 日次グラフで描く最大バー本数（直近約2年。長期は年表示の月次バーで見る）
+  private let maxDailyBars = 732
 
   /// スクロールで一度に見せる日数（週=7 / 月=30 / 年=365 のローリングウィンドウ）
   private var visibleSpanDays: Int {
@@ -172,84 +187,52 @@ struct StatisticsView: View {
       : "wide"
   }
 
-  // MARK: - 集計（トレンドグラフ＝全取得分 / カード＝表示中ウィンドウ）
+  // MARK: - 集計
+  // 生のログは保持せず、取得時に日別/月別の合計へ畳み込んで @State にキャッシュする。
+  // スクロールでは再集計せず、表示中ウィンドウのカード値だけを可視日数ぶん走査する。
 
-  private var totalsByDate: [String: NutritionValues] {
-    Dictionary(grouping: items, by: { $0.logDate })
-      .mapValues { dayItems in
-        dayItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
-      }
-  }
-
-  /// 月初日をキーにした月別集計（年表示のトレンド用）
-  private var totalsByMonth: [Date: NutritionValues] {
-    var dict: [Date: NutritionValues] = [:]
-    for item in items {
-      guard let d = StatisticsView.parseLogDate(item.logDate) else { continue }
-      let key = monthStart(d)
-      dict[key] = (dict[key] ?? .zero) + item.nutritionValues
-    }
-    return dict
-  }
-
-  /// トレンドグラフ用の系列（取得範囲全体。記録のない期間は0）。
-  /// 年は月次、それ以外は日次で集計する。
-  private var trendPoints: [StatsDayPoint] {
-    if barUnit == .month {
-      let totals = totalsByMonth
-      return months(in: loadInterval).map { m in
-        StatsDayPoint(date: m, values: totals[m] ?? .zero)
-      }
-    } else {
-      let totals = totalsByDate
-      return days(in: loadInterval).map { day in
-        StatsDayPoint(date: day, values: totals[LogItemDTO.formatLogDate(day)] ?? .zero)
+  /// 表示中ウィンドウの集計（1パス・O(可視日数)。件数に依存しない）
+  private var visibleStats: VisibleStats {
+    var s = VisibleStats()
+    let target = nutritionGoalsManager.targetCalories
+    for day in days(in: visibleInterval) {
+      let key = LogItemDTO.formatLogDate(day)
+      guard let v = dayTotals[key] else { continue }
+      s.total = s.total + v
+      s.recordedDays += 1
+      if target > 0, v.calories > 0, v.calories <= target { s.daysOnTarget += 1 }
+      if let meals = dayMealTotals[key] {
+        for (meal, mv) in meals {
+          s.mealTotals[meal] = (s.mealTotals[meal] ?? .zero) + mv
+        }
       }
     }
+    return s
   }
 
-  /// 表示中ウィンドウ内のログ
-  private var visibleItems: [LogItemDTO] {
-    let from = LogItemDTO.formatLogDate(visibleInterval.start)
-    let to = LogItemDTO.formatLogDate(visibleInterval.end)
-    return items.filter { $0.logDate >= from && $0.logDate <= to }
-  }
-
-  private var visibleTotalsByDate: [String: NutritionValues] {
-    Dictionary(grouping: visibleItems, by: { $0.logDate })
-      .mapValues { dayItems in
-        dayItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
-      }
-  }
-
-  private var periodTotal: NutritionValues {
-    visibleItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
-  }
-
-  /// 記録があった日数（1件以上ログがある日）
-  private var recordedDayCount: Int { visibleTotalsByDate.count }
-
-  private var average: NutritionValues {
-    let n = Double(recordedDayCount)
+  private func averageValues(_ stats: VisibleStats) -> NutritionValues {
+    let n = Double(stats.recordedDays)
     guard n > 0 else { return .zero }
-    let t = periodTotal
+    let t = stats.total
     return NutritionValues(
       calories: t.calories / n, netCarbs: t.netCarbs / n,
       dietaryFiber: t.dietaryFiber / n, fat: t.fat / n, protein: t.protein / n)
   }
 
-  /// カロリー目標以内だった記録日数
-  private var daysOnTarget: Int {
-    let target = nutritionGoalsManager.targetCalories
-    guard target > 0 else { return 0 }
-    return visibleTotalsByDate.values.filter { $0.calories > 0 && $0.calories <= target }.count
-  }
-
-  private var mealTypeTotals: [(type: MealType, values: NutritionValues)] {
-    MealType.allCases.map { mealType in
-      let v = visibleItems.filter { $0.mealType == mealType }
-        .reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
-      return (mealType, v)
+  /// キャッシュからトレンド系列を再構築（取得時・期間タイプ変更時のみ呼ぶ）
+  private func rebuildTrendPoints() {
+    if barUnit == .month {
+      // 年：取得済みの全月（10年でも約120本と軽量）
+      trendPoints = months(in: loadInterval).map { m in
+        StatsDayPoint(date: m, values: monthTotals[m] ?? .zero)
+      }
+    } else {
+      // 週/月：直近 maxDailyBars 日ぶんに制限（長期は年表示で見る）
+      let all = days(in: loadInterval)
+      let capped = all.count > maxDailyBars ? Array(all.suffix(maxDailyBars)) : all
+      trendPoints = capped.map { day in
+        StatsDayPoint(date: day, values: dayTotals[LogItemDTO.formatLogDate(day)] ?? .zero)
+      }
     }
   }
 
@@ -260,13 +243,14 @@ struct StatisticsView: View {
       VStack(spacing: 16) {
         periodSelector
 
-        if items.isEmpty && !isLoading {
-          emptyState
-        } else {
+        if !dayTotals.isEmpty {
+          let stats = visibleStats
           trendCard
-          averageCard
-          pfcBalanceCard
-          mealTypeCard
+          averageCard(stats)
+          pfcBalanceCard(stats)
+          mealTypeCard(stats)
+        } else if !isLoading {
+          emptyState
         }
       }
       .padding(.vertical)
@@ -275,7 +259,7 @@ struct StatisticsView: View {
     .navigationTitle(NSLocalizedString("Statistics", comment: "Statistics tab"))
     .navigationBarTitleDisplayMode(.inline)
     .overlay {
-      if isLoading && items.isEmpty {
+      if isLoading && dayTotals.isEmpty {
         ProgressView()
       }
     }
@@ -287,6 +271,7 @@ struct StatisticsView: View {
     }
     .onChange(of: periodType) { _, _ in
       scrollToRecentWindow()
+      rebuildTrendPoints()
     }
     .onChange(of: scrollPosition) { _, _ in
       Task { await loadOlderIfNeeded() }
@@ -480,30 +465,30 @@ struct StatisticsView: View {
 
   // MARK: - 平均・達成率カード
 
-  @ViewBuilder
-  private var averageCard: some View {
-    statsCard(title: NSLocalizedString("Daily Average", comment: "Statistics section")) {
+  private func averageCard(_ stats: VisibleStats) -> some View {
+    let avg = averageValues(stats)
+    return statsCard(title: NSLocalizedString("Daily Average", comment: "Statistics section")) {
       HStack(spacing: 16) {
         CalorieRingView(
-          calories: average.calories,
+          calories: avg.calories,
           targetCalories: nutritionGoalsManager.targetCalories
         )
         VStack(spacing: 8) {
           MacroBarView(
             label: NSLocalizedString("Protein", comment: "Nutrient label"),
-            value: average.protein, maxValue: nutritionGoalsManager.targetProtein,
+            value: avg.protein, maxValue: nutritionGoalsManager.targetProtein,
             color: .blue, icon: "p.circle.fill")
           MacroBarView(
             label: NSLocalizedString("Fat", comment: "Nutrient label"),
-            value: average.fat, maxValue: nutritionGoalsManager.targetFat,
+            value: avg.fat, maxValue: nutritionGoalsManager.targetFat,
             color: .yellow, icon: "f.circle.fill")
           MacroBarView(
             label: NSLocalizedString("Sugar", comment: "Nutrient label"),
-            value: average.netCarbs, maxValue: nutritionGoalsManager.targetNetCarbs,
+            value: avg.netCarbs, maxValue: nutritionGoalsManager.targetNetCarbs,
             color: .green, icon: "s.circle.fill")
           MacroBarView(
             label: NSLocalizedString("Dietary Fiber", comment: "Nutrient label"),
-            value: average.dietaryFiber, maxValue: nutritionGoalsManager.targetFiber,
+            value: avg.dietaryFiber, maxValue: nutritionGoalsManager.targetFiber,
             color: .brown, icon: "leaf.circle.fill")
         }
       }
@@ -521,7 +506,7 @@ struct StatisticsView: View {
         Text(
           String(
             format: NSLocalizedString("%d / %d days", comment: "Days on target / recorded days"),
-            daysOnTarget, recordedDayCount)
+            stats.daysOnTarget, stats.recordedDays)
         )
         .font(.subheadline.weight(.semibold))
       }
@@ -530,14 +515,13 @@ struct StatisticsView: View {
 
   // MARK: - PFCバランスカード
 
-  @ViewBuilder
-  private var pfcBalanceCard: some View {
-    let p = periodTotal.protein * 4
-    let f = periodTotal.fat * 9
-    let c = periodTotal.carbs * 4
+  private func pfcBalanceCard(_ stats: VisibleStats) -> some View {
+    let p = stats.total.protein * 4
+    let f = stats.total.fat * 9
+    let c = stats.total.carbs * 4
     let total = p + f + c
 
-    statsCard(title: NSLocalizedString("PFC Balance", comment: "Statistics section")) {
+    return statsCard(title: NSLocalizedString("PFC Balance", comment: "Statistics section")) {
       if total > 0 {
         let segments: [(label: String, value: Double, color: Color)] = [
           (NSLocalizedString("Protein", comment: "Nutrient label"), p, .blue),
@@ -581,12 +565,14 @@ struct StatisticsView: View {
 
   // MARK: - 食事タイプ別カード
 
-  @ViewBuilder
-  private var mealTypeCard: some View {
-    let totals = mealTypeTotals.filter { $0.values.calories > 0 }
+  private func mealTypeCard(_ stats: VisibleStats) -> some View {
+    let periodTotal = stats.total
+    let totals = MealType.allCases
+      .map { (type: $0, values: stats.mealTotals[$0] ?? .zero) }
+      .filter { $0.values.calories > 0 }
     let maxCalories = totals.map { $0.values.calories }.max() ?? 0
 
-    statsCard(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
+    return statsCard(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
       VStack(spacing: 14) {
         // 期間全体の合計
         VStack(alignment: .leading, spacing: 6) {
@@ -684,28 +670,32 @@ struct StatisticsView: View {
     isLoading = true
     defer { isLoading = false }
     do {
+      let fetched: [LogItemDTO]
       if periodType == .custom {
-        items = try await APIClient.shared.fetchLogItems(
+        fetched = try await APIClient.shared.fetchLogItems(
           from: LogItemDTO.formatLogDate(loadInterval.start),
           to: LogItemDTO.formatLogDate(loadInterval.end))
+        loadedStart = loadInterval.start
       } else {
         let start = calendar.date(byAdding: .day, value: -initialSpanDays, to: referenceDate)!
-        items = try await APIClient.shared.fetchLogItems(
+        fetched = try await APIClient.shared.fetchLogItems(
           from: LogItemDTO.formatLogDate(start),
           to: LogItemDTO.formatLogDate(referenceDate))
         loadedStart = start
       }
+      ingest(fetched, reset: true)
     } catch {
       print("StatisticsView load error: \(error)")
     }
   }
 
   /// スクロールで取得済みの端に近づいたら、さらに過去を1年分追加取得する。
-  /// 既存データは保持したまま追記し、スクロール位置は維持される。
+  /// 既存の集計は保持したまま畳み込み、スクロール位置は維持される。
   /// @MainActor で直列化し、同じ範囲の二重取得（重複集計）を防ぐ。
   @MainActor
   private func loadOlderIfNeeded() async {
-    guard periodType != .custom, !isLoadingMore else { return }
+    // 日次（週/月）は直近2年に固定。過去への追加取得は年表示のみ（月次バーで軽い）
+    guard periodType == .year, !isLoadingMore else { return }
     // 表示ウィンドウの先頭が、取得済み開始から1ウィンドウ分以内に来たら先読み
     let threshold = calendar.date(byAdding: .day, value: visibleSpanDays, to: loadedStart)!
     guard calendar.startOfDay(for: scrollPosition) <= threshold else { return }
@@ -721,10 +711,39 @@ struct StatisticsView: View {
       let older = try await APIClient.shared.fetchLogItems(
         from: LogItemDTO.formatLogDate(newStart),
         to: LogItemDTO.formatLogDate(chunkEnd))
-      items.append(contentsOf: older)
       loadedStart = newStart
+      ingest(older, reset: false)
     } catch {
       print("StatisticsView loadOlder error: \(error)")
     }
+  }
+
+  /// 取得したログを日別/月別の合計へ畳み込む（生のログは破棄）。
+  /// reset=true で全キャッシュをクリアしてから取り込む。
+  private func ingest(_ newItems: [LogItemDTO], reset: Bool) {
+    if reset {
+      dayTotals = [:]
+      dayMealTotals = [:]
+      monthTotals = [:]
+    }
+    var dt = dayTotals
+    var dmt = dayMealTotals
+    var mt = monthTotals
+    for item in newItems {
+      let key = item.logDate
+      let v = item.nutritionValues
+      dt[key] = (dt[key] ?? .zero) + v
+      var meals = dmt[key] ?? [:]
+      meals[item.mealType] = (meals[item.mealType] ?? .zero) + v
+      dmt[key] = meals
+      if let d = StatisticsView.parseLogDate(key) {
+        let mkey = monthStart(d)
+        mt[mkey] = (mt[mkey] ?? .zero) + v
+      }
+    }
+    dayTotals = dt
+    dayMealTotals = dmt
+    monthTotals = mt
+    rebuildTrendPoints()
   }
 }

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -64,7 +64,8 @@ struct StatisticsView: View {
   @EnvironmentObject private var nutritionGoalsManager: NutritionGoalsManager
 
   @State private var periodType: StatsPeriodType = .week
-  @State private var anchorDate = Date()
+  /// スクロール表示中ウィンドウの先頭日（週/月モードで使用）
+  @State private var scrollPosition = Date()
   @State private var customStart = Calendar.current.date(byAdding: .day, value: -6, to: Date())!
   @State private var customEnd = Date()
   @State private var trendMetric: TrendMetric = .calories
@@ -73,29 +74,41 @@ struct StatisticsView: View {
   @State private var isLoading = false
 
   private let calendar = Calendar.current
+  /// 起動時点の今日（スクロール範囲の基準。ビュー生成中に固定）
+  private let referenceDate = Calendar.current.startOfDay(for: Date())
+
+  /// スクロールで一度に見せる日数（週=7 / 月=30 のローリングウィンドウ）
+  private var domainDays: Int { periodType == .month ? 30 : 7 }
+  private var domainSeconds: TimeInterval { Double(domainDays) * 86400 }
 
   // MARK: - 期間計算
 
-  private var interval: (start: Date, end: Date) {
+  /// データ取得範囲。週/月は約1年分まとめて取得し、スクロールはメモリ上で処理する
+  private var loadInterval: (start: Date, end: Date) {
     switch periodType {
-    case .week:
-      let start = calendar.dateInterval(of: .weekOfYear, for: anchorDate)?.start
-        ?? calendar.startOfDay(for: anchorDate)
-      let end = calendar.date(byAdding: .day, value: 6, to: start)!
-      return (start, end)
-    case .month:
-      let start = calendar.dateInterval(of: .month, for: anchorDate)?.start
-        ?? calendar.startOfDay(for: anchorDate)
-      let end = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: start)!
-      return (start, end)
     case .custom:
-      let s = calendar.startOfDay(for: min(customStart, customEnd))
-      let e = calendar.startOfDay(for: max(customStart, customEnd))
-      return (s, e)
+      return (
+        calendar.startOfDay(for: min(customStart, customEnd)),
+        calendar.startOfDay(for: max(customStart, customEnd)))
+    default:
+      let start = calendar.date(byAdding: .day, value: -364, to: referenceDate)!
+      return (start, referenceDate)
     }
   }
 
-  private var days: [Date] {
+  /// 現在表示中（スクロール位置）のウィンドウ。各カードの集計対象
+  private var visibleInterval: (start: Date, end: Date) {
+    switch periodType {
+    case .custom:
+      return loadInterval
+    default:
+      let start = calendar.startOfDay(for: scrollPosition)
+      let end = calendar.date(byAdding: .day, value: domainDays - 1, to: start)!
+      return (start, end)
+    }
+  }
+
+  private func days(in interval: (start: Date, end: Date)) -> [Date] {
     var result: [Date] = []
     var d = calendar.startOfDay(for: interval.start)
     let end = calendar.startOfDay(for: interval.end)
@@ -107,11 +120,12 @@ struct StatisticsView: View {
     return result
   }
 
+  /// 取得範囲（=トレンドグラフのスクロール範囲）が変わったときだけ再フェッチ
   private var taskID: String {
-    "\(LogItemDTO.formatLogDate(interval.start))-\(LogItemDTO.formatLogDate(interval.end))"
+    "\(LogItemDTO.formatLogDate(loadInterval.start))-\(LogItemDTO.formatLogDate(loadInterval.end))"
   }
 
-  // MARK: - 集計
+  // MARK: - 集計（トレンドグラフ＝全取得分 / カード＝表示中ウィンドウ）
 
   private var totalsByDate: [String: NutritionValues] {
     Dictionary(grouping: items, by: { $0.logDate })
@@ -120,19 +134,34 @@ struct StatisticsView: View {
       }
   }
 
+  /// トレンドグラフ用の日別系列（取得範囲全体。記録のない日は0）
   private var dailyPoints: [StatsDayPoint] {
     let totals = totalsByDate
-    return days.map { day in
+    return days(in: loadInterval).map { day in
       StatsDayPoint(date: day, values: totals[LogItemDTO.formatLogDate(day)] ?? .zero)
     }
   }
 
+  /// 表示中ウィンドウ内のログ
+  private var visibleItems: [LogItemDTO] {
+    let from = LogItemDTO.formatLogDate(visibleInterval.start)
+    let to = LogItemDTO.formatLogDate(visibleInterval.end)
+    return items.filter { $0.logDate >= from && $0.logDate <= to }
+  }
+
+  private var visibleTotalsByDate: [String: NutritionValues] {
+    Dictionary(grouping: visibleItems, by: { $0.logDate })
+      .mapValues { dayItems in
+        dayItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
+      }
+  }
+
   private var periodTotal: NutritionValues {
-    items.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
+    visibleItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
   }
 
   /// 記録があった日数（1件以上ログがある日）
-  private var recordedDayCount: Int { totalsByDate.count }
+  private var recordedDayCount: Int { visibleTotalsByDate.count }
 
   private var average: NutritionValues {
     let n = Double(recordedDayCount)
@@ -147,12 +176,12 @@ struct StatisticsView: View {
   private var daysOnTarget: Int {
     let target = nutritionGoalsManager.targetCalories
     guard target > 0 else { return 0 }
-    return totalsByDate.values.filter { $0.calories > 0 && $0.calories <= target }.count
+    return visibleTotalsByDate.values.filter { $0.calories > 0 && $0.calories <= target }.count
   }
 
   private var mealTypeTotals: [(type: MealType, values: NutritionValues)] {
     MealType.allCases.map { mealType in
-      let v = items.filter { $0.mealType == mealType }
+      let v = visibleItems.filter { $0.mealType == mealType }
         .reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
       return (mealType, v)
     }
@@ -190,6 +219,19 @@ struct StatisticsView: View {
     .refreshable {
       await load()
     }
+    .onChange(of: periodType) { _, _ in
+      scrollToRecentWindow()
+    }
+    .onAppear {
+      scrollToRecentWindow()
+    }
+  }
+
+  /// 直近のウィンドウ（最新日が今日になる位置）へスクロール位置を合わせる
+  private func scrollToRecentWindow() {
+    guard periodType != .custom else { return }
+    scrollPosition = calendar.date(
+      byAdding: .day, value: -(domainDays - 1), to: referenceDate)!
   }
 
   // MARK: - 期間セレクタ
@@ -219,7 +261,7 @@ struct StatisticsView: View {
       } else {
         HStack {
           Button {
-            shiftPeriod(forward: false)
+            shiftWindow(forward: false)
           } label: {
             Image(systemName: "chevron.left")
           }
@@ -228,10 +270,11 @@ struct StatisticsView: View {
             .font(.subheadline.weight(.medium))
           Spacer()
           Button {
-            shiftPeriod(forward: true)
+            shiftWindow(forward: true)
           } label: {
             Image(systemName: "chevron.right")
           }
+          .disabled(isAtLatestWindow)
         }
       }
     }
@@ -244,19 +287,27 @@ struct StatisticsView: View {
 
   private var periodLabel: String {
     let f = DateFormatter()
-    f.dateFormat = periodType == .month ? "yyyy/MM" : "M/d"
-    if periodType == .month {
-      return f.string(from: interval.start)
-    }
-    return "\(f.string(from: interval.start)) - \(f.string(from: interval.end))"
+    f.dateFormat = "M/d"
+    return "\(f.string(from: visibleInterval.start)) - \(f.string(from: visibleInterval.end))"
   }
 
-  private func shiftPeriod(forward: Bool) {
-    let value = forward ? 1 : -1
-    let component: Calendar.Component = periodType == .month ? .month : .weekOfYear
-    if let d = calendar.date(byAdding: component, value: value, to: anchorDate) {
-      anchorDate = d
+  /// 表示可能な最新ウィンドウの先頭日
+  private var latestWindowStart: Date {
+    calendar.date(byAdding: .day, value: -(domainDays - 1), to: loadInterval.end)!
+  }
+
+  private var isAtLatestWindow: Bool {
+    calendar.startOfDay(for: scrollPosition) >= calendar.startOfDay(for: latestWindowStart)
+  }
+
+  /// チェブロンで1ウィンドウ分スクロール（取得範囲内にクランプ）
+  private func shiftWindow(forward: Bool) {
+    let delta = (forward ? 1 : -1) * domainDays
+    guard let shifted = calendar.date(byAdding: .day, value: delta, to: scrollPosition) else {
+      return
     }
+    let clamped = min(max(shifted, loadInterval.start), latestWindowStart)
+    withAnimation { scrollPosition = clamped }
   }
 
   // MARK: - 空状態
@@ -288,29 +339,43 @@ struct StatisticsView: View {
       .pickerStyle(.segmented)
       .padding(.bottom, 4)
 
-      let goal = trendGoal
+      if periodType == .custom {
+        // カスタムは範囲全体を一画面に表示（スクロールなし）
+        trendChart
+          .frame(height: 200)
+      } else {
+        // 週/月は横スクロールで期間を移動（ヘルスケア風）
+        trendChart
+          .chartScrollableAxes(.horizontal)
+          .chartXVisibleDomain(length: domainSeconds)
+          .chartScrollPosition(x: $scrollPosition)
+          .chartScrollTargetBehavior(.paging)
+          .frame(height: 200)
+      }
+    }
+  }
 
-      Chart {
-        ForEach(dailyPoints) { point in
-          BarMark(
-            x: .value("Date", point.date, unit: .day),
-            y: .value("Value", trendMetric.value(point.values))
-          )
-          .foregroundStyle(trendMetric.color.gradient)
-        }
-        if goal > 0 {
-          RuleMark(y: .value("Goal", goal))
-            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
-            .foregroundStyle(.secondary)
-        }
+  private var trendChart: some View {
+    let goal = trendGoal
+    return Chart {
+      ForEach(dailyPoints) { point in
+        BarMark(
+          x: .value("Date", point.date, unit: .day),
+          y: .value("Value", trendMetric.value(point.values))
+        )
+        .foregroundStyle(trendMetric.color.gradient)
       }
-      .chartXAxis {
-        AxisMarks(values: .stride(by: .day, count: xAxisStride)) { value in
-          AxisGridLine()
-          AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
-        }
+      if goal > 0 {
+        RuleMark(y: .value("Goal", goal))
+          .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
+          .foregroundStyle(.secondary)
       }
-      .frame(height: 200)
+    }
+    .chartXAxis {
+      AxisMarks(values: .stride(by: .day, count: xAxisStride)) { _ in
+        AxisGridLine()
+        AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
+      }
     }
   }
 
@@ -324,10 +389,15 @@ struct StatisticsView: View {
   }
 
   private var xAxisStride: Int {
-    let count = days.count
-    if count <= 8 { return 1 }
-    if count <= 16 { return 2 }
-    return max(count / 8, 1)
+    switch periodType {
+    case .week: return 1
+    case .month: return 5
+    case .custom:
+      let count = days(in: loadInterval).count
+      if count <= 8 { return 1 }
+      if count <= 16 { return 2 }
+      return max(count / 8, 1)
+    }
   }
 
   // MARK: - 平均・達成率カード
@@ -537,8 +607,8 @@ struct StatisticsView: View {
     defer { isLoading = false }
     do {
       items = try await APIClient.shared.fetchLogItems(
-        from: LogItemDTO.formatLogDate(interval.start),
-        to: LogItemDTO.formatLogDate(interval.end))
+        from: LogItemDTO.formatLogDate(loadInterval.start),
+        to: LogItemDTO.formatLogDate(loadInterval.end))
     } catch {
       print("StatisticsView load error: \(error)")
     }

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -74,8 +74,6 @@ struct StatisticsView: View {
   @EnvironmentObject private var nutritionGoalsManager: NutritionGoalsManager
 
   @State private var periodType: StatsPeriodType = .week
-  /// スクロール表示中ウィンドウの先頭日（週/月/年モードで使用）
-  @State private var scrollPosition = Date()
   @State private var customStart = Calendar.current.date(byAdding: .day, value: -6, to: Date())!
   @State private var customEnd = Date()
   @State private var trendMetric: TrendMetric = .calories
@@ -84,61 +82,91 @@ struct StatisticsView: View {
   @State private var dayTotals: [String: NutritionValues] = [:]
   @State private var dayMealTotals: [String: [MealType: NutritionValues]] = [:]
   @State private var monthTotals: [Date: NutritionValues] = [:]
-  @State private var trendPoints: [StatsDayPoint] = []
-  /// 取得済みの最も古い日。スクロールで端に近づくと過去へ伸ばす
+
+  // ページング用：各ページ（1期間）の先頭日を古い順→新しい順で並べる
+  @State private var pageAnchors: [Date] = []
+  /// 現在表示中ページの先頭日（スクロールに追従）
+  @State private var currentPageID: Date?
+
+  /// 取得済みの最も古い日。ページを過去へ送ると追加取得して伸ばす
   @State private var loadedStart = Calendar.current.date(byAdding: .day, value: -730, to: Date())!
   @State private var isLoading = false
   @State private var isLoadingMore = false
 
   private let calendar = Calendar.current
-  /// 起動時点の今日（スクロール範囲の基準。ビュー生成中に固定）
+  /// 起動時点の今日（基準。ビュー生成中に固定）
   private let referenceDate = Calendar.current.startOfDay(for: Date())
 
-  /// 初回取得する日数（年表示でも遡れるよう2年分）
+  /// 初回取得する日数（2年分）
   private let initialSpanDays = 730
   /// 端に達したとき追加で遡る日数（1年ずつ）
   private let chunkDays = 365
-  /// 日次グラフで描く最大バー本数（直近約2年。長期は年表示の月次バーで見る）
-  private let maxDailyBars = 732
-
-  /// スクロールで一度に見せる日数（週=7 / 月=30 / 年=365 のローリングウィンドウ）
-  private var visibleSpanDays: Int {
-    switch periodType {
-    case .week: return 7
-    case .month: return 30
-    case .year: return 365
-    case .custom: return max(days(in: loadInterval).count, 1)
-    }
-  }
-  private var domainSeconds: TimeInterval { Double(visibleSpanDays) * 86400 }
+  /// ページ生成の上限（このぶんだけ過去へスクロールできる）
+  private let horizonYears = 16
 
   /// トレンドグラフのバー単位（年は月次集計、それ以外は日次）
   private var barUnit: Calendar.Component { periodType == .year ? .month : .day }
 
-  // MARK: - 期間計算
+  // MARK: - 期間・ページのカレンダー計算
 
-  /// データ取得範囲。週/月/年はまとめて取得し、スクロールはメモリ上で処理する
-  private var loadInterval: (start: Date, end: Date) {
+  private func periodStart(_ date: Date) -> Date {
     switch periodType {
+    case .week:
+      return calendar.dateInterval(of: .weekOfYear, for: date)?.start
+        ?? calendar.startOfDay(for: date)
+    case .month:
+      return calendar.dateInterval(of: .month, for: date)?.start
+        ?? calendar.startOfDay(for: date)
+    case .year:
+      return calendar.dateInterval(of: .year, for: date)?.start
+        ?? calendar.startOfDay(for: date)
     case .custom:
-      return (
-        calendar.startOfDay(for: min(customStart, customEnd)),
-        calendar.startOfDay(for: max(customStart, customEnd)))
-    default:
-      return (loadedStart, referenceDate)
+      return calendar.startOfDay(for: min(customStart, customEnd))
     }
   }
 
-  /// 現在表示中（スクロール位置）のウィンドウ。各カードの集計対象
-  private var visibleInterval: (start: Date, end: Date) {
+  private func nextPeriodStart(_ start: Date) -> Date {
     switch periodType {
-    case .custom:
-      return loadInterval
-    default:
-      let start = calendar.startOfDay(for: scrollPosition)
-      let end = calendar.date(byAdding: .day, value: visibleSpanDays - 1, to: start)!
-      return (start, end)
+    case .week: return calendar.date(byAdding: .day, value: 7, to: start)!
+    case .month: return calendar.date(byAdding: .month, value: 1, to: start)!
+    case .year: return calendar.date(byAdding: .year, value: 1, to: start)!
+    case .custom: return calendar.date(byAdding: .day, value: 1, to: start)!
     }
+  }
+
+  private func prevPeriodStart(_ start: Date) -> Date {
+    switch periodType {
+    case .week: return calendar.date(byAdding: .day, value: -7, to: start)!
+    case .month: return calendar.date(byAdding: .month, value: -1, to: start)!
+    case .year: return calendar.date(byAdding: .year, value: -1, to: start)!
+    case .custom: return calendar.date(byAdding: .day, value: -1, to: start)!
+    }
+  }
+
+  private func periodEnd(forStart start: Date) -> Date {
+    calendar.date(byAdding: .day, value: -1, to: nextPeriodStart(start))!
+  }
+
+  /// 取得（フェッチ）に使う範囲。カスタムは指定範囲
+  private var loadInterval: (start: Date, end: Date) {
+    if periodType == .custom {
+      return (
+        calendar.startOfDay(for: min(customStart, customEnd)),
+        calendar.startOfDay(for: max(customStart, customEnd)))
+    }
+    return (loadedStart, referenceDate)
+  }
+
+  /// 現在表示中ページの先頭日（未設定なら最新ページ）
+  private var currentAnchor: Date {
+    currentPageID ?? pageAnchors.last ?? periodStart(referenceDate)
+  }
+
+  /// 各カードの集計対象ウィンドウ
+  private var visibleInterval: (start: Date, end: Date) {
+    if periodType == .custom { return loadInterval }
+    let s = currentAnchor
+    return (s, periodEnd(forStart: s))
   }
 
   private func days(in interval: (start: Date, end: Date)) -> [Date] {
@@ -188,8 +216,8 @@ struct StatisticsView: View {
   }
 
   // MARK: - 集計
-  // 生のログは保持せず、取得時に日別/月別の合計へ畳み込んで @State にキャッシュする。
-  // スクロールでは再集計せず、表示中ウィンドウのカード値だけを可視日数ぶん走査する。
+  // 生のログは保持せず、取得時に日別/月別合計へ畳み込んで @State にキャッシュする。
+  // 各ページ・カードはキャッシュを参照するだけで、スクロール中の重い再集計はしない。
 
   /// 表示中ウィンドウの集計（1パス・O(可視日数)。件数に依存しない）
   private var visibleStats: VisibleStats {
@@ -219,18 +247,14 @@ struct StatisticsView: View {
       dietaryFiber: t.dietaryFiber / n, fat: t.fat / n, protein: t.protein / n)
   }
 
-  /// キャッシュからトレンド系列を再構築（取得時・期間タイプ変更時のみ呼ぶ）
-  private func rebuildTrendPoints() {
+  /// 1ページぶんのバー系列をキャッシュから生成
+  private func points(start: Date, end: Date) -> [StatsDayPoint] {
     if barUnit == .month {
-      // 年：取得済みの全月（10年でも約120本と軽量）
-      trendPoints = months(in: loadInterval).map { m in
+      return months(in: (start, end)).map { m in
         StatsDayPoint(date: m, values: monthTotals[m] ?? .zero)
       }
     } else {
-      // 週/月：直近 maxDailyBars 日ぶんに制限（長期は年表示で見る）
-      let all = days(in: loadInterval)
-      let capped = all.count > maxDailyBars ? Array(all.suffix(maxDailyBars)) : all
-      trendPoints = capped.map { day in
+      return days(in: (start, end)).map { day in
         StatsDayPoint(date: day, values: dayTotals[LogItemDTO.formatLogDate(day)] ?? .zero)
       }
     }
@@ -270,22 +294,34 @@ struct StatisticsView: View {
       await load()
     }
     .onChange(of: periodType) { _, _ in
-      scrollToRecentWindow()
-      rebuildTrendPoints()
+      rebuildPageAnchors()
+      currentPageID = pageAnchors.last
     }
-    .onChange(of: scrollPosition) { _, _ in
+    .onChange(of: currentPageID) { _, _ in
       Task { await loadOlderIfNeeded() }
     }
     .onAppear {
-      scrollToRecentWindow()
+      if pageAnchors.isEmpty { rebuildPageAnchors() }
+      if currentPageID == nil { currentPageID = pageAnchors.last }
     }
   }
 
-  /// 直近のウィンドウ（最新日が今日になる位置）へスクロール位置を合わせる
-  private func scrollToRecentWindow() {
-    guard periodType != .custom else { return }
-    scrollPosition = calendar.date(
-      byAdding: .day, value: -(visibleSpanDays - 1), to: referenceDate)!
+  /// 過去 horizonYears 年ぶんのページ先頭日を生成（古い順→新しい順）。
+  /// LazyHStack が仮想化するので本数が多くても描画は表示中ページのみ。
+  private func rebuildPageAnchors() {
+    guard periodType != .custom else {
+      pageAnchors = []
+      return
+    }
+    let newest = periodStart(referenceDate)
+    let horizon = calendar.date(byAdding: .year, value: -horizonYears, to: referenceDate)!
+    var anchors: [Date] = []
+    var a = newest
+    while a >= horizon {
+      anchors.append(a)
+      a = prevPeriodStart(a)
+    }
+    pageAnchors = anchors.reversed()
   }
 
   // MARK: - 期間セレクタ
@@ -315,20 +351,21 @@ struct StatisticsView: View {
       } else {
         HStack {
           Button {
-            shiftWindow(forward: false)
+            stepPage(forward: false)
           } label: {
             Image(systemName: "chevron.left")
           }
+          .disabled(currentAnchor <= (pageAnchors.first ?? currentAnchor))
           Spacer()
           Text(periodLabel)
             .font(.subheadline.weight(.medium))
           Spacer()
           Button {
-            shiftWindow(forward: true)
+            stepPage(forward: true)
           } label: {
             Image(systemName: "chevron.right")
           }
-          .disabled(isAtLatestWindow)
+          .disabled(currentAnchor >= (pageAnchors.last ?? currentAnchor))
         }
       }
     }
@@ -341,27 +378,26 @@ struct StatisticsView: View {
 
   private var periodLabel: String {
     let f = DateFormatter()
-    f.dateFormat = "M/d"
-    return "\(f.string(from: visibleInterval.start)) - \(f.string(from: visibleInterval.end))"
-  }
-
-  /// 表示可能な最新ウィンドウの先頭日
-  private var latestWindowStart: Date {
-    calendar.date(byAdding: .day, value: -(visibleSpanDays - 1), to: loadInterval.end)!
-  }
-
-  private var isAtLatestWindow: Bool {
-    calendar.startOfDay(for: scrollPosition) >= calendar.startOfDay(for: latestWindowStart)
-  }
-
-  /// チェブロンで1ウィンドウ分スクロール（取得範囲内にクランプ）
-  private func shiftWindow(forward: Bool) {
-    let delta = (forward ? 1 : -1) * visibleSpanDays
-    guard let shifted = calendar.date(byAdding: .day, value: delta, to: scrollPosition) else {
-      return
+    switch periodType {
+    case .year:
+      f.dateFormat = "yyyy"
+      return f.string(from: currentAnchor)
+    case .month:
+      f.dateFormat = "yyyy/MM"
+      return f.string(from: currentAnchor)
+    default:
+      f.dateFormat = "M/d"
+      let interval = visibleInterval
+      return "\(f.string(from: interval.start)) - \(f.string(from: interval.end))"
     }
-    let clamped = min(max(shifted, loadInterval.start), latestWindowStart)
-    withAnimation { scrollPosition = clamped }
+  }
+
+  /// チェブロンで隣のページへ（スクロールも追従）
+  private func stepPage(forward: Bool) {
+    guard let idx = pageAnchors.firstIndex(of: currentAnchor) else { return }
+    let nidx = forward ? idx + 1 : idx - 1
+    guard pageAnchors.indices.contains(nidx) else { return }
+    withAnimation { currentPageID = pageAnchors[nidx] }
   }
 
   // MARK: - 空状態
@@ -395,62 +431,63 @@ struct StatisticsView: View {
 
       if periodType == .custom {
         // カスタムは範囲全体を一画面に表示（スクロールなし）
-        trendChart
+        pageChart(start: loadInterval.start, end: loadInterval.end)
           .frame(height: 200)
       } else {
-        // 週/月は横スクロールで期間を移動（ヘルスケア風）
-        trendChart
-          .chartScrollableAxes(.horizontal)
-          .chartXVisibleDomain(length: domainSeconds)
-          .chartScrollPosition(x: $scrollPosition)
-          .chartScrollTargetBehavior(.paging)
-          .frame(height: 200)
+        // 1期間=1ページを横ページングで並べる。LazyHStackが表示中ページのみ描画
+        ScrollView(.horizontal) {
+          LazyHStack(spacing: 0) {
+            ForEach(pageAnchors, id: \.self) { anchor in
+              pageChart(start: anchor, end: periodEnd(forStart: anchor))
+                .containerRelativeFrame(.horizontal)
+            }
+          }
+          .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.paging)
+        .scrollPosition(id: $currentPageID)
+        .defaultScrollAnchor(.trailing)
+        .scrollIndicators(.hidden)
+        .frame(height: 200)
       }
     }
   }
 
-  private var trendChart: some View {
+  private func pageChart(start: Date, end: Date) -> some View {
+    let pts = points(start: start, end: end)
     let goal = trendGoal
     return Chart {
-      ForEach(trendPoints) { point in
+      ForEach(pts) { point in
         BarMark(
           x: .value("Date", point.date, unit: barUnit),
           y: .value("Value", trendMetric.value(point.values))
         )
         .foregroundStyle(trendMetric.color.gradient)
       }
-      // 年（月次集計）の目標ラインは月合計の概算（1日目標×30）
       if goal > 0 {
+        // 年（月次集計）の目標ラインは月合計の概算（1日目標×30）
         RuleMark(y: .value("Goal", barUnit == .month ? goal * 30 : goal))
           .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
           .foregroundStyle(.secondary)
       }
     }
-    .chartXAxis {
-      if barUnit == .month {
-        AxisMarks(values: .stride(by: .month, count: 2)) { _ in
-          AxisGridLine()
-          AxisValueLabel(format: .dateTime.year(.twoDigits).month(.narrow))
-        }
+    .chartXScale(domain: start...calendar.date(byAdding: .day, value: 1, to: end)!)
+    .chartXAxis { trendAxis }
+  }
+
+  private var trendAxis: some AxisContent {
+    AxisMarks(values: .stride(by: axisStrideUnit, count: axisStrideCount)) { _ in
+      AxisGridLine()
+      if periodType == .year {
+        AxisValueLabel(format: .dateTime.month(.narrow))
       } else {
-        AxisMarks(values: .stride(by: .day, count: xAxisStride)) { _ in
-          AxisGridLine()
-          AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
-        }
+        AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
       }
     }
   }
 
-  private var trendGoal: Double {
-    switch trendMetric {
-    case .calories: return nutritionGoalsManager.targetCalories
-    case .protein: return nutritionGoalsManager.targetProtein
-    case .fat: return nutritionGoalsManager.targetFat
-    case .carbs: return nutritionGoalsManager.targetNetCarbs + nutritionGoalsManager.targetFiber
-    }
-  }
-
-  private var xAxisStride: Int {
+  private var axisStrideUnit: Calendar.Component { periodType == .year ? .month : .day }
+  private var axisStrideCount: Int {
     switch periodType {
     case .week: return 1
     case .month: return 5
@@ -460,6 +497,15 @@ struct StatisticsView: View {
       if count <= 8 { return 1 }
       if count <= 16 { return 2 }
       return max(count / 8, 1)
+    }
+  }
+
+  private var trendGoal: Double {
+    switch trendMetric {
+    case .calories: return nutritionGoalsManager.targetCalories
+    case .protein: return nutritionGoalsManager.targetProtein
+    case .fat: return nutritionGoalsManager.targetFat
+    case .carbs: return nutritionGoalsManager.targetNetCarbs + nutritionGoalsManager.targetFiber
     }
   }
 
@@ -689,18 +735,17 @@ struct StatisticsView: View {
     }
   }
 
-  /// スクロールで取得済みの端に近づいたら、さらに過去を1年分追加取得する。
-  /// 既存の集計は保持したまま畳み込み、スクロール位置は維持される。
+  /// 表示中ページが取得済みの端に近づいたら、さらに過去を1年分追加取得する。
+  /// 既存の集計は保持したまま畳み込み、ページ位置は維持される。
   /// @MainActor で直列化し、同じ範囲の二重取得（重複集計）を防ぐ。
   @MainActor
   private func loadOlderIfNeeded() async {
-    // 日次（週/月）は直近2年に固定。過去への追加取得は年表示のみ（月次バーで軽い）
-    guard periodType == .year, !isLoadingMore else { return }
-    // 表示ウィンドウの先頭が、取得済み開始から1ウィンドウ分以内に来たら先読み
-    let threshold = calendar.date(byAdding: .day, value: visibleSpanDays, to: loadedStart)!
-    guard calendar.startOfDay(for: scrollPosition) <= threshold else { return }
-    // 際限ない取得を避けるため最大10年で打ち切り
-    let earliest = calendar.date(byAdding: .year, value: -10, to: referenceDate)!
+    guard periodType != .custom, !isLoadingMore else { return }
+    // 表示中ページの先頭が、取得済み開始から1期間分以内に来たら先読み
+    let threshold = nextPeriodStart(calendar.startOfDay(for: loadedStart))
+    guard currentAnchor <= threshold else { return }
+    // 際限ない取得を避けるため最大 horizonYears 年で打ち切り
+    let earliest = calendar.date(byAdding: .year, value: -horizonYears, to: referenceDate)!
     guard loadedStart > earliest else { return }
 
     isLoadingMore = true
@@ -744,6 +789,5 @@ struct StatisticsView: View {
     dayTotals = dt
     dayMealTotals = dmt
     monthTotals = mt
-    rebuildTrendPoints()
   }
 }

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -4,13 +4,14 @@ import SwiftUI
 // MARK: - 期間タイプ
 
 enum StatsPeriodType: CaseIterable, Identifiable {
-  case week, month, custom
+  case week, month, year, custom
   var id: Self { self }
 
   var localizedName: String {
     switch self {
     case .week: return NSLocalizedString("Week", comment: "Statistics period")
     case .month: return NSLocalizedString("Month", comment: "Statistics period")
+    case .year: return NSLocalizedString("Year", comment: "Statistics period")
     case .custom: return NSLocalizedString("Custom", comment: "Statistics period")
     }
   }
@@ -64,26 +65,44 @@ struct StatisticsView: View {
   @EnvironmentObject private var nutritionGoalsManager: NutritionGoalsManager
 
   @State private var periodType: StatsPeriodType = .week
-  /// スクロール表示中ウィンドウの先頭日（週/月モードで使用）
+  /// スクロール表示中ウィンドウの先頭日（週/月/年モードで使用）
   @State private var scrollPosition = Date()
   @State private var customStart = Calendar.current.date(byAdding: .day, value: -6, to: Date())!
   @State private var customEnd = Date()
   @State private var trendMetric: TrendMetric = .calories
 
   @State private var items: [LogItemDTO] = []
+  /// 取得済みの最も古い日。スクロールで端に近づくと過去へ伸ばす
+  @State private var loadedStart = Calendar.current.date(byAdding: .day, value: -730, to: Date())!
   @State private var isLoading = false
+  @State private var isLoadingMore = false
 
   private let calendar = Calendar.current
   /// 起動時点の今日（スクロール範囲の基準。ビュー生成中に固定）
   private let referenceDate = Calendar.current.startOfDay(for: Date())
 
-  /// スクロールで一度に見せる日数（週=7 / 月=30 のローリングウィンドウ）
-  private var domainDays: Int { periodType == .month ? 30 : 7 }
-  private var domainSeconds: TimeInterval { Double(domainDays) * 86400 }
+  /// 初回取得する日数（年表示でも遡れるよう2年分）
+  private let initialSpanDays = 730
+  /// 端に達したとき追加で遡る日数（1年ずつ）
+  private let chunkDays = 365
+
+  /// スクロールで一度に見せる日数（週=7 / 月=30 / 年=365 のローリングウィンドウ）
+  private var visibleSpanDays: Int {
+    switch periodType {
+    case .week: return 7
+    case .month: return 30
+    case .year: return 365
+    case .custom: return max(days(in: loadInterval).count, 1)
+    }
+  }
+  private var domainSeconds: TimeInterval { Double(visibleSpanDays) * 86400 }
+
+  /// トレンドグラフのバー単位（年は月次集計、それ以外は日次）
+  private var barUnit: Calendar.Component { periodType == .year ? .month : .day }
 
   // MARK: - 期間計算
 
-  /// データ取得範囲。週/月は約1年分まとめて取得し、スクロールはメモリ上で処理する
+  /// データ取得範囲。週/月/年はまとめて取得し、スクロールはメモリ上で処理する
   private var loadInterval: (start: Date, end: Date) {
     switch periodType {
     case .custom:
@@ -91,8 +110,7 @@ struct StatisticsView: View {
         calendar.startOfDay(for: min(customStart, customEnd)),
         calendar.startOfDay(for: max(customStart, customEnd)))
     default:
-      let start = calendar.date(byAdding: .day, value: -364, to: referenceDate)!
-      return (start, referenceDate)
+      return (loadedStart, referenceDate)
     }
   }
 
@@ -103,7 +121,7 @@ struct StatisticsView: View {
       return loadInterval
     default:
       let start = calendar.startOfDay(for: scrollPosition)
-      let end = calendar.date(byAdding: .day, value: domainDays - 1, to: start)!
+      let end = calendar.date(byAdding: .day, value: visibleSpanDays - 1, to: start)!
       return (start, end)
     }
   }
@@ -120,9 +138,38 @@ struct StatisticsView: View {
     return result
   }
 
-  /// 取得範囲（=トレンドグラフのスクロール範囲）が変わったときだけ再フェッチ
+  private func monthStart(_ date: Date) -> Date {
+    calendar.dateInterval(of: .month, for: date)?.start ?? calendar.startOfDay(for: date)
+  }
+
+  private func months(in interval: (start: Date, end: Date)) -> [Date] {
+    var result: [Date] = []
+    var m = monthStart(interval.start)
+    let last = monthStart(interval.end)
+    while m <= last {
+      result.append(m)
+      guard let next = calendar.date(byAdding: .month, value: 1, to: m) else { break }
+      m = next
+    }
+    return result
+  }
+
+  /// "yyyy-MM-dd" 文字列を Date へ（formatLogDate と対）
+  private static let logDateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyy-MM-dd"
+    return f
+  }()
+
+  private static func parseLogDate(_ string: String) -> Date? {
+    logDateFormatter.date(from: string)
+  }
+
+  /// 取得範囲の種類が変わったときだけ再フェッチ（週/月/年は同じ"wide"扱い）
   private var taskID: String {
-    "\(LogItemDTO.formatLogDate(loadInterval.start))-\(LogItemDTO.formatLogDate(loadInterval.end))"
+    periodType == .custom
+      ? "custom-\(LogItemDTO.formatLogDate(loadInterval.start))-\(LogItemDTO.formatLogDate(loadInterval.end))"
+      : "wide"
   }
 
   // MARK: - 集計（トレンドグラフ＝全取得分 / カード＝表示中ウィンドウ）
@@ -134,11 +181,30 @@ struct StatisticsView: View {
       }
   }
 
-  /// トレンドグラフ用の日別系列（取得範囲全体。記録のない日は0）
-  private var dailyPoints: [StatsDayPoint] {
-    let totals = totalsByDate
-    return days(in: loadInterval).map { day in
-      StatsDayPoint(date: day, values: totals[LogItemDTO.formatLogDate(day)] ?? .zero)
+  /// 月初日をキーにした月別集計（年表示のトレンド用）
+  private var totalsByMonth: [Date: NutritionValues] {
+    var dict: [Date: NutritionValues] = [:]
+    for item in items {
+      guard let d = StatisticsView.parseLogDate(item.logDate) else { continue }
+      let key = monthStart(d)
+      dict[key] = (dict[key] ?? .zero) + item.nutritionValues
+    }
+    return dict
+  }
+
+  /// トレンドグラフ用の系列（取得範囲全体。記録のない期間は0）。
+  /// 年は月次、それ以外は日次で集計する。
+  private var trendPoints: [StatsDayPoint] {
+    if barUnit == .month {
+      let totals = totalsByMonth
+      return months(in: loadInterval).map { m in
+        StatsDayPoint(date: m, values: totals[m] ?? .zero)
+      }
+    } else {
+      let totals = totalsByDate
+      return days(in: loadInterval).map { day in
+        StatsDayPoint(date: day, values: totals[LogItemDTO.formatLogDate(day)] ?? .zero)
+      }
     }
   }
 
@@ -222,6 +288,9 @@ struct StatisticsView: View {
     .onChange(of: periodType) { _, _ in
       scrollToRecentWindow()
     }
+    .onChange(of: scrollPosition) { _, _ in
+      Task { await loadOlderIfNeeded() }
+    }
     .onAppear {
       scrollToRecentWindow()
     }
@@ -231,7 +300,7 @@ struct StatisticsView: View {
   private func scrollToRecentWindow() {
     guard periodType != .custom else { return }
     scrollPosition = calendar.date(
-      byAdding: .day, value: -(domainDays - 1), to: referenceDate)!
+      byAdding: .day, value: -(visibleSpanDays - 1), to: referenceDate)!
   }
 
   // MARK: - 期間セレクタ
@@ -293,7 +362,7 @@ struct StatisticsView: View {
 
   /// 表示可能な最新ウィンドウの先頭日
   private var latestWindowStart: Date {
-    calendar.date(byAdding: .day, value: -(domainDays - 1), to: loadInterval.end)!
+    calendar.date(byAdding: .day, value: -(visibleSpanDays - 1), to: loadInterval.end)!
   }
 
   private var isAtLatestWindow: Bool {
@@ -302,7 +371,7 @@ struct StatisticsView: View {
 
   /// チェブロンで1ウィンドウ分スクロール（取得範囲内にクランプ）
   private func shiftWindow(forward: Bool) {
-    let delta = (forward ? 1 : -1) * domainDays
+    let delta = (forward ? 1 : -1) * visibleSpanDays
     guard let shifted = calendar.date(byAdding: .day, value: delta, to: scrollPosition) else {
       return
     }
@@ -358,23 +427,31 @@ struct StatisticsView: View {
   private var trendChart: some View {
     let goal = trendGoal
     return Chart {
-      ForEach(dailyPoints) { point in
+      ForEach(trendPoints) { point in
         BarMark(
-          x: .value("Date", point.date, unit: .day),
+          x: .value("Date", point.date, unit: barUnit),
           y: .value("Value", trendMetric.value(point.values))
         )
         .foregroundStyle(trendMetric.color.gradient)
       }
+      // 年（月次集計）の目標ラインは月合計の概算（1日目標×30）
       if goal > 0 {
-        RuleMark(y: .value("Goal", goal))
+        RuleMark(y: .value("Goal", barUnit == .month ? goal * 30 : goal))
           .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
           .foregroundStyle(.secondary)
       }
     }
     .chartXAxis {
-      AxisMarks(values: .stride(by: .day, count: xAxisStride)) { _ in
-        AxisGridLine()
-        AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
+      if barUnit == .month {
+        AxisMarks(values: .stride(by: .month, count: 2)) { _ in
+          AxisGridLine()
+          AxisValueLabel(format: .dateTime.year(.twoDigits).month(.narrow))
+        }
+      } else {
+        AxisMarks(values: .stride(by: .day, count: xAxisStride)) { _ in
+          AxisGridLine()
+          AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
+        }
       }
     }
   }
@@ -392,6 +469,7 @@ struct StatisticsView: View {
     switch periodType {
     case .week: return 1
     case .month: return 5
+    case .year: return 1
     case .custom:
       let count = days(in: loadInterval).count
       if count <= 8 { return 1 }
@@ -606,11 +684,47 @@ struct StatisticsView: View {
     isLoading = true
     defer { isLoading = false }
     do {
-      items = try await APIClient.shared.fetchLogItems(
-        from: LogItemDTO.formatLogDate(loadInterval.start),
-        to: LogItemDTO.formatLogDate(loadInterval.end))
+      if periodType == .custom {
+        items = try await APIClient.shared.fetchLogItems(
+          from: LogItemDTO.formatLogDate(loadInterval.start),
+          to: LogItemDTO.formatLogDate(loadInterval.end))
+      } else {
+        let start = calendar.date(byAdding: .day, value: -initialSpanDays, to: referenceDate)!
+        items = try await APIClient.shared.fetchLogItems(
+          from: LogItemDTO.formatLogDate(start),
+          to: LogItemDTO.formatLogDate(referenceDate))
+        loadedStart = start
+      }
     } catch {
       print("StatisticsView load error: \(error)")
+    }
+  }
+
+  /// スクロールで取得済みの端に近づいたら、さらに過去を1年分追加取得する。
+  /// 既存データは保持したまま追記し、スクロール位置は維持される。
+  /// @MainActor で直列化し、同じ範囲の二重取得（重複集計）を防ぐ。
+  @MainActor
+  private func loadOlderIfNeeded() async {
+    guard periodType != .custom, !isLoadingMore else { return }
+    // 表示ウィンドウの先頭が、取得済み開始から1ウィンドウ分以内に来たら先読み
+    let threshold = calendar.date(byAdding: .day, value: visibleSpanDays, to: loadedStart)!
+    guard calendar.startOfDay(for: scrollPosition) <= threshold else { return }
+    // 際限ない取得を避けるため最大10年で打ち切り
+    let earliest = calendar.date(byAdding: .year, value: -10, to: referenceDate)!
+    guard loadedStart > earliest else { return }
+
+    isLoadingMore = true
+    defer { isLoadingMore = false }
+    let newStart = calendar.date(byAdding: .day, value: -chunkDays, to: loadedStart)!
+    let chunkEnd = calendar.date(byAdding: .day, value: -1, to: loadedStart)!
+    do {
+      let older = try await APIClient.shared.fetchLogItems(
+        from: LogItemDTO.formatLogDate(newStart),
+        to: LogItemDTO.formatLogDate(chunkEnd))
+      items.append(contentsOf: older)
+      loadedStart = newStart
+    } catch {
+      print("StatisticsView loadOlder error: \(error)")
     }
   }
 }

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -1,0 +1,509 @@
+import Charts
+import SwiftUI
+
+// MARK: - 期間タイプ
+
+enum StatsPeriodType: CaseIterable, Identifiable {
+  case week, month, custom
+  var id: Self { self }
+
+  var localizedName: String {
+    switch self {
+    case .week: return NSLocalizedString("Week", comment: "Statistics period")
+    case .month: return NSLocalizedString("Month", comment: "Statistics period")
+    case .custom: return NSLocalizedString("Custom", comment: "Statistics period")
+    }
+  }
+}
+
+// MARK: - トレンドで表示する指標
+
+enum TrendMetric: CaseIterable, Identifiable {
+  case calories, protein, fat, carbs
+  var id: Self { self }
+
+  var localizedName: String {
+    switch self {
+    case .calories: return NSLocalizedString("Calories", comment: "Nutrient label")
+    case .protein: return NSLocalizedString("Protein", comment: "Nutrient label")
+    case .fat: return NSLocalizedString("Fat", comment: "Nutrient label")
+    case .carbs: return NSLocalizedString("Carbs (Sugar + Fiber)", comment: "Nutrient label")
+    }
+  }
+
+  var color: Color {
+    switch self {
+    case .calories: return .orange
+    case .protein: return .blue
+    case .fat: return .yellow
+    case .carbs: return .green
+    }
+  }
+
+  func value(_ v: NutritionValues) -> Double {
+    switch self {
+    case .calories: return v.calories
+    case .protein: return v.protein
+    case .fat: return v.fat
+    case .carbs: return v.carbs
+    }
+  }
+}
+
+// MARK: - 日別集計の1点
+
+struct StatsDayPoint: Identifiable {
+  let date: Date
+  let values: NutritionValues
+  var id: Date { date }
+}
+
+// MARK: - 統計画面
+
+struct StatisticsView: View {
+  @EnvironmentObject private var nutritionGoalsManager: NutritionGoalsManager
+
+  @State private var periodType: StatsPeriodType = .week
+  @State private var anchorDate = Date()
+  @State private var customStart = Calendar.current.date(byAdding: .day, value: -6, to: Date())!
+  @State private var customEnd = Date()
+  @State private var trendMetric: TrendMetric = .calories
+
+  @State private var items: [LogItemDTO] = []
+  @State private var isLoading = false
+
+  private let calendar = Calendar.current
+
+  // MARK: - 期間計算
+
+  private var interval: (start: Date, end: Date) {
+    switch periodType {
+    case .week:
+      let start = calendar.dateInterval(of: .weekOfYear, for: anchorDate)?.start
+        ?? calendar.startOfDay(for: anchorDate)
+      let end = calendar.date(byAdding: .day, value: 6, to: start)!
+      return (start, end)
+    case .month:
+      let start = calendar.dateInterval(of: .month, for: anchorDate)?.start
+        ?? calendar.startOfDay(for: anchorDate)
+      let end = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: start)!
+      return (start, end)
+    case .custom:
+      let s = calendar.startOfDay(for: min(customStart, customEnd))
+      let e = calendar.startOfDay(for: max(customStart, customEnd))
+      return (s, e)
+    }
+  }
+
+  private var days: [Date] {
+    var result: [Date] = []
+    var d = calendar.startOfDay(for: interval.start)
+    let end = calendar.startOfDay(for: interval.end)
+    while d <= end {
+      result.append(d)
+      guard let next = calendar.date(byAdding: .day, value: 1, to: d) else { break }
+      d = next
+    }
+    return result
+  }
+
+  private var taskID: String {
+    "\(LogItemDTO.formatLogDate(interval.start))-\(LogItemDTO.formatLogDate(interval.end))"
+  }
+
+  // MARK: - 集計
+
+  private var totalsByDate: [String: NutritionValues] {
+    Dictionary(grouping: items, by: { $0.logDate })
+      .mapValues { dayItems in
+        dayItems.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
+      }
+  }
+
+  private var dailyPoints: [StatsDayPoint] {
+    let totals = totalsByDate
+    return days.map { day in
+      StatsDayPoint(date: day, values: totals[LogItemDTO.formatLogDate(day)] ?? .zero)
+    }
+  }
+
+  private var periodTotal: NutritionValues {
+    items.reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
+  }
+
+  /// 記録があった日数（1件以上ログがある日）
+  private var recordedDayCount: Int { totalsByDate.count }
+
+  private var average: NutritionValues {
+    let n = Double(recordedDayCount)
+    guard n > 0 else { return .zero }
+    let t = periodTotal
+    return NutritionValues(
+      calories: t.calories / n, netCarbs: t.netCarbs / n,
+      dietaryFiber: t.dietaryFiber / n, fat: t.fat / n, protein: t.protein / n)
+  }
+
+  /// カロリー目標以内だった記録日数
+  private var daysOnTarget: Int {
+    let target = nutritionGoalsManager.targetCalories
+    guard target > 0 else { return 0 }
+    return totalsByDate.values.filter { $0.calories > 0 && $0.calories <= target }.count
+  }
+
+  private var mealTypeTotals: [(type: MealType, values: NutritionValues)] {
+    MealType.allCases.map { mealType in
+      let v = items.filter { $0.mealType == mealType }
+        .reduce(NutritionValues.zero) { $0 + $1.nutritionValues }
+      return (mealType, v)
+    }
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        periodSelector
+
+        if items.isEmpty && !isLoading {
+          emptyState
+        } else {
+          trendCard
+          averageCard
+          pfcBalanceCard
+          mealTypeCard
+        }
+      }
+      .padding(.vertical)
+    }
+    .background(Color(UIColor.systemGroupedBackground))
+    .navigationTitle(NSLocalizedString("Statistics", comment: "Statistics tab"))
+    .navigationBarTitleDisplayMode(.inline)
+    .overlay {
+      if isLoading && items.isEmpty {
+        ProgressView()
+      }
+    }
+    .task(id: taskID) {
+      await load()
+    }
+    .refreshable {
+      await load()
+    }
+  }
+
+  // MARK: - 期間セレクタ
+
+  @ViewBuilder
+  private var periodSelector: some View {
+    VStack(spacing: 12) {
+      Picker("", selection: $periodType) {
+        ForEach(StatsPeriodType.allCases) { type in
+          Text(type.localizedName).tag(type)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      if periodType == .custom {
+        HStack {
+          DatePicker(
+            NSLocalizedString("From", comment: "Range start"),
+            selection: $customStart, displayedComponents: .date
+          )
+          DatePicker(
+            NSLocalizedString("To", comment: "Range end"),
+            selection: $customEnd, displayedComponents: .date
+          )
+        }
+        .font(.caption)
+      } else {
+        HStack {
+          Button {
+            shiftPeriod(forward: false)
+          } label: {
+            Image(systemName: "chevron.left")
+          }
+          Spacer()
+          Text(periodLabel)
+            .font(.subheadline.weight(.medium))
+          Spacer()
+          Button {
+            shiftPeriod(forward: true)
+          } label: {
+            Image(systemName: "chevron.right")
+          }
+        }
+      }
+    }
+    .padding()
+    .background(Color(UIColor.systemBackground))
+    .cornerRadius(12)
+    .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+    .padding(.horizontal)
+  }
+
+  private var periodLabel: String {
+    let f = DateFormatter()
+    f.dateFormat = periodType == .month ? "yyyy/MM" : "M/d"
+    if periodType == .month {
+      return f.string(from: interval.start)
+    }
+    return "\(f.string(from: interval.start)) - \(f.string(from: interval.end))"
+  }
+
+  private func shiftPeriod(forward: Bool) {
+    let value = forward ? 1 : -1
+    let component: Calendar.Component = periodType == .month ? .month : .weekOfYear
+    if let d = calendar.date(byAdding: component, value: value, to: anchorDate) {
+      anchorDate = d
+    }
+  }
+
+  // MARK: - 空状態
+
+  @ViewBuilder
+  private var emptyState: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "chart.bar.xaxis")
+        .font(.system(size: 40))
+        .foregroundColor(.secondary)
+      Text(NSLocalizedString("No records in this period", comment: "Empty statistics"))
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 60)
+  }
+
+  // MARK: - トレンドカード
+
+  @ViewBuilder
+  private var trendCard: some View {
+    statsCard(title: NSLocalizedString("Trend", comment: "Statistics section")) {
+      Picker("", selection: $trendMetric) {
+        ForEach(TrendMetric.allCases) { metric in
+          Text(metric.localizedName).tag(metric)
+        }
+      }
+      .pickerStyle(.segmented)
+      .padding(.bottom, 4)
+
+      let goal = trendGoal
+
+      Chart {
+        ForEach(dailyPoints) { point in
+          BarMark(
+            x: .value("Date", point.date, unit: .day),
+            y: .value("Value", trendMetric.value(point.values))
+          )
+          .foregroundStyle(trendMetric.color.gradient)
+        }
+        if goal > 0 {
+          RuleMark(y: .value("Goal", goal))
+            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .chartXAxis {
+        AxisMarks(values: .stride(by: .day, count: xAxisStride)) { value in
+          AxisGridLine()
+          AxisValueLabel(format: .dateTime.month(.defaultDigits).day())
+        }
+      }
+      .frame(height: 200)
+    }
+  }
+
+  private var trendGoal: Double {
+    switch trendMetric {
+    case .calories: return nutritionGoalsManager.targetCalories
+    case .protein: return nutritionGoalsManager.targetProtein
+    case .fat: return nutritionGoalsManager.targetFat
+    case .carbs: return nutritionGoalsManager.targetNetCarbs + nutritionGoalsManager.targetFiber
+    }
+  }
+
+  private var xAxisStride: Int {
+    let count = days.count
+    if count <= 8 { return 1 }
+    if count <= 16 { return 2 }
+    return max(count / 8, 1)
+  }
+
+  // MARK: - 平均・達成率カード
+
+  @ViewBuilder
+  private var averageCard: some View {
+    statsCard(title: NSLocalizedString("Daily Average", comment: "Statistics section")) {
+      HStack(spacing: 16) {
+        CalorieRingView(
+          calories: average.calories,
+          targetCalories: nutritionGoalsManager.targetCalories
+        )
+        VStack(spacing: 8) {
+          MacroBarView(
+            label: NSLocalizedString("Protein", comment: "Nutrient label"),
+            value: average.protein, maxValue: nutritionGoalsManager.targetProtein,
+            color: .blue, icon: "p.circle.fill")
+          MacroBarView(
+            label: NSLocalizedString("Fat", comment: "Nutrient label"),
+            value: average.fat, maxValue: nutritionGoalsManager.targetFat,
+            color: .yellow, icon: "f.circle.fill")
+          MacroBarView(
+            label: NSLocalizedString("Sugar", comment: "Nutrient label"),
+            value: average.netCarbs, maxValue: nutritionGoalsManager.targetNetCarbs,
+            color: .green, icon: "s.circle.fill")
+          MacroBarView(
+            label: NSLocalizedString("Dietary Fiber", comment: "Nutrient label"),
+            value: average.dietaryFiber, maxValue: nutritionGoalsManager.targetFiber,
+            color: .brown, icon: "leaf.circle.fill")
+        }
+      }
+
+      Divider()
+
+      HStack {
+        Label(
+          NSLocalizedString("Days on Target", comment: "Statistics metric"),
+          systemImage: "checkmark.circle.fill"
+        )
+        .font(.subheadline)
+        .foregroundColor(.green)
+        Spacer()
+        Text(
+          String(
+            format: NSLocalizedString("%d / %d days", comment: "Days on target / recorded days"),
+            daysOnTarget, recordedDayCount)
+        )
+        .font(.subheadline.weight(.semibold))
+      }
+    }
+  }
+
+  // MARK: - PFCバランスカード
+
+  @ViewBuilder
+  private var pfcBalanceCard: some View {
+    let p = periodTotal.protein * 4
+    let f = periodTotal.fat * 9
+    let c = periodTotal.carbs * 4
+    let total = p + f + c
+
+    statsCard(title: NSLocalizedString("PFC Balance", comment: "Statistics section")) {
+      if total > 0 {
+        let segments: [(label: String, value: Double, color: Color)] = [
+          (NSLocalizedString("Protein", comment: "Nutrient label"), p, .blue),
+          (NSLocalizedString("Fat", comment: "Nutrient label"), f, .yellow),
+          (NSLocalizedString("Carbs (Sugar + Fiber)", comment: "Nutrient label"), c, .green),
+        ]
+        HStack(spacing: 20) {
+          Chart(segments, id: \.label) { seg in
+            SectorMark(
+              angle: .value("Energy", seg.value),
+              innerRadius: .ratio(0.6),
+              angularInset: 1.5
+            )
+            .foregroundStyle(seg.color)
+          }
+          .frame(width: 120, height: 120)
+
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(segments, id: \.label) { seg in
+              HStack(spacing: 6) {
+                Circle().fill(seg.color).frame(width: 8, height: 8)
+                Text(seg.label)
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+                Spacer()
+                Text("\(Int((seg.value / total * 100).rounded()))%")
+                  .font(.subheadline.weight(.semibold))
+              }
+            }
+          }
+        }
+      } else {
+        Text(NSLocalizedString("No records in this period", comment: "Empty statistics"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 20)
+      }
+    }
+  }
+
+  // MARK: - 食事タイプ別カード
+
+  @ViewBuilder
+  private var mealTypeCard: some View {
+    let totals = mealTypeTotals
+    let maxCalories = totals.map { $0.values.calories }.max() ?? 0
+
+    statsCard(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
+      VStack(spacing: 10) {
+        ForEach(totals, id: \.type) { entry in
+          HStack(spacing: 10) {
+            Image(systemName: entry.type.iconName)
+              .font(.system(size: 14))
+              .foregroundColor(entry.type.accentColor)
+              .frame(width: 20)
+            Text(entry.type.localizedName)
+              .font(.subheadline)
+              .frame(width: 64, alignment: .leading)
+
+            GeometryReader { geo in
+              ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                  .fill(entry.type.accentColor.opacity(0.12))
+                  .frame(height: 8)
+                RoundedRectangle(cornerRadius: 3)
+                  .fill(entry.type.accentColor)
+                  .frame(
+                    width: maxCalories > 0
+                      ? geo.size.width * (entry.values.calories / maxCalories) : 0,
+                    height: 8)
+              }
+            }
+            .frame(height: 8)
+
+            Text("\(NutritionFormatter.formatNutrition(entry.values.calories))")
+              .font(.caption.weight(.medium))
+              .frame(width: 52, alignment: .trailing)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - 共通カード
+
+  @ViewBuilder
+  private func statsCard<Content: View>(
+    title: String, @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text(title)
+        .font(.headline)
+      content()
+    }
+    .padding()
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color(UIColor.systemBackground))
+    .cornerRadius(12)
+    .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 1)
+    .padding(.horizontal)
+  }
+
+  // MARK: - データ取得
+
+  private func load() async {
+    isLoading = true
+    defer { isLoading = false }
+    do {
+      items = try await APIClient.shared.fetchLogItems(
+        from: LogItemDTO.formatLogDate(interval.start),
+        to: LogItemDTO.formatLogDate(interval.end))
+    } catch {
+      print("StatisticsView load error: \(error)")
+    }
+  }
+}

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -435,39 +435,49 @@ struct StatisticsView: View {
 
   @ViewBuilder
   private var mealTypeCard: some View {
-    let totals = mealTypeTotals
+    let totals = mealTypeTotals.filter { $0.values.calories > 0 }
     let maxCalories = totals.map { $0.values.calories }.max() ?? 0
 
     statsCard(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
-      VStack(spacing: 10) {
+      VStack(spacing: 14) {
         ForEach(totals, id: \.type) { entry in
-          HStack(spacing: 10) {
-            Image(systemName: entry.type.iconName)
-              .font(.system(size: 14))
-              .foregroundColor(entry.type.accentColor)
-              .frame(width: 20)
-            Text(entry.type.localizedName)
-              .font(.subheadline)
-              .frame(width: 64, alignment: .leading)
+          VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+              Image(systemName: entry.type.iconName)
+                .font(.system(size: 14))
+                .foregroundColor(entry.type.accentColor)
+                .frame(width: 20)
+              Text(entry.type.localizedName)
+                .font(.subheadline.weight(.medium))
+              Spacer()
+              Text("\(NutritionFormatter.formatNutrition(entry.values.calories))")
+                .font(.subheadline.weight(.semibold))
+                + Text(" kcal")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
 
             GeometryReader { geo in
               ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 3)
                   .fill(entry.type.accentColor.opacity(0.12))
-                  .frame(height: 8)
+                  .frame(height: 6)
                 RoundedRectangle(cornerRadius: 3)
                   .fill(entry.type.accentColor)
                   .frame(
                     width: maxCalories > 0
                       ? geo.size.width * (entry.values.calories / maxCalories) : 0,
-                    height: 8)
+                    height: 6)
               }
             }
-            .frame(height: 8)
+            .frame(height: 6)
 
-            Text("\(NutritionFormatter.formatNutrition(entry.values.calories))")
-              .font(.caption.weight(.medium))
-              .frame(width: 52, alignment: .trailing)
+            HStack(spacing: 6) {
+              MacroChip(label: "P", value: entry.values.protein, color: .blue)
+              MacroChip(label: "F", value: entry.values.fat, color: .yellow)
+              MacroChip(label: "S", value: entry.values.netCarbs, color: .green)
+              MacroChip(label: "Fb", value: entry.values.dietaryFiber, color: .brown)
+            }
           }
         }
       }

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -456,6 +456,10 @@ struct StatisticsView: View {
   private func pageChart(start: Date, end: Date) -> some View {
     let pts = points(start: start, end: end)
     let goal = trendGoal
+    let goalLine = barUnit == .month ? goal * 30 : goal
+    // 全バー0のページ（未取得など）でもY軸が退化しないよう上限を確保
+    let maxValue = pts.map { trendMetric.value($0.values) }.max() ?? 0
+    let yMax = max(maxValue * 1.1, goalLine * 1.1, 1)
     return Chart {
       ForEach(pts) { point in
         BarMark(
@@ -466,12 +470,13 @@ struct StatisticsView: View {
       }
       if goal > 0 {
         // 年（月次集計）の目標ラインは月合計の概算（1日目標×30）
-        RuleMark(y: .value("Goal", barUnit == .month ? goal * 30 : goal))
+        RuleMark(y: .value("Goal", goalLine))
           .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
           .foregroundStyle(.secondary)
       }
     }
     .chartXScale(domain: start...calendar.date(byAdding: .day, value: 1, to: end)!)
+    .chartYScale(domain: 0...yMax)
     .chartXAxis { trendAxis }
   }
 
@@ -735,23 +740,25 @@ struct StatisticsView: View {
     }
   }
 
-  /// 表示中ページが取得済みの端に近づいたら、さらに過去を1年分追加取得する。
+  /// 表示中ページが取得済みより古ければ、そのページを丸ごと含む範囲を1度だけ取得する。
   /// 既存の集計は保持したまま畳み込み、ページ位置は維持される。
+  /// 取得済みなら即 return するので、スクロールで連続発火しても多重取得しない。
   /// @MainActor で直列化し、同じ範囲の二重取得（重複集計）を防ぐ。
   @MainActor
   private func loadOlderIfNeeded() async {
     guard periodType != .custom, !isLoadingMore else { return }
-    // 表示中ページの先頭が、取得済み開始から1期間分以内に来たら先読み
-    let threshold = nextPeriodStart(calendar.startOfDay(for: loadedStart))
-    guard currentAnchor <= threshold else { return }
+    let loadedStartDay = calendar.startOfDay(for: loadedStart)
+    // 表示中ページを完全に含むのに必要な開始日（1期間ぶん先読み）
+    let needFrom = prevPeriodStart(periodStart(currentAnchor))
+    guard needFrom < loadedStartDay else { return }  // 既に取得済み
     // 際限ない取得を避けるため最大 horizonYears 年で打ち切り
     let earliest = calendar.date(byAdding: .year, value: -horizonYears, to: referenceDate)!
-    guard loadedStart > earliest else { return }
+    let newStart = max(needFrom, calendar.startOfDay(for: earliest))
+    guard newStart < loadedStartDay else { return }
 
     isLoadingMore = true
     defer { isLoadingMore = false }
-    let newStart = calendar.date(byAdding: .day, value: -chunkDays, to: loadedStart)!
-    let chunkEnd = calendar.date(byAdding: .day, value: -1, to: loadedStart)!
+    let chunkEnd = calendar.date(byAdding: .day, value: -1, to: loadedStartDay)!
     do {
       let older = try await APIClient.shared.fetchLogItems(
         from: LogItemDTO.formatLogDate(newStart),

--- a/cloudflare/src/routes/logItems.test.ts
+++ b/cloudflare/src/routes/logItems.test.ts
@@ -1,0 +1,120 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { issueSessionJwt } from '../middleware/auth';
+
+const TEST_SECRET = 'dev-and-test-secret';
+
+beforeAll(async () => {
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS food_masters (
+      id TEXT PRIMARY KEY COLLATE NOCASE,
+      brand_name TEXT NOT NULL DEFAULT '',
+      product_name TEXT NOT NULL,
+      calories REAL NOT NULL DEFAULT 0,
+      dietary_fiber REAL NOT NULL DEFAULT 0,
+      net_carbs REAL NOT NULL DEFAULT 0,
+      fat REAL NOT NULL DEFAULT 0,
+      protein REAL NOT NULL DEFAULT 0,
+      portion_size REAL NOT NULL DEFAULT 1.0,
+      portion_unit TEXT NOT NULL DEFAULT 'g',
+      unique_key TEXT NOT NULL UNIQUE,
+      created_by TEXT NOT NULL
+    )`
+  ).run();
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS log_items (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      log_date TEXT NOT NULL,
+      meal_type TEXT NOT NULL,
+      number_of_servings REAL NOT NULL DEFAULT 1.0,
+      food_master_id TEXT COLLATE NOCASE REFERENCES food_masters(id) ON DELETE SET NULL,
+      nutrition_snapshot_json TEXT,
+      is_master_deleted INTEGER NOT NULL DEFAULT 0
+    )`
+  ).run();
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS user_food_stats (
+      user_id TEXT NOT NULL,
+      food_master_id TEXT NOT NULL COLLATE NOCASE REFERENCES food_masters(id) ON DELETE CASCADE,
+      usage_count INTEGER NOT NULL DEFAULT 0,
+      last_used_date TEXT,
+      last_number_of_servings REAL NOT NULL DEFAULT 1.0,
+      PRIMARY KEY (user_id, food_master_id)
+    )`
+  ).run();
+});
+
+beforeEach(async () => {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM user_food_stats'),
+    env.DB.prepare('DELETE FROM log_items'),
+    env.DB.prepare('DELETE FROM food_masters'),
+  ]);
+});
+
+async function jwtFor(userId: string): Promise<string> {
+  return issueSessionJwt(userId, TEST_SECRET);
+}
+
+function insertLogItem(id: string, userId: string, logDate: string) {
+  return env.DB.prepare(
+    `INSERT INTO log_items (id, user_id, timestamp, log_date, meal_type)
+     VALUES (?, ?, ?, ?, 'Breakfast')`
+  ).bind(id, userId, `${logDate}T00:00:00Z`, logDate);
+}
+
+async function fetchItems(userId: string, queryString: string) {
+  const res = await SELF.fetch(`http://localhost/api/log-items?${queryString}`, {
+    headers: { Authorization: `Bearer ${await jwtFor(userId)}` },
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { items: { id: string }[] };
+  return body.items.map((i) => i.id);
+}
+
+describe('GET /api/log-items?from&to (期間範囲取得)', () => {
+  it('from〜to の範囲内（両端含む）のログだけを返す', async () => {
+    await env.DB.batch([
+      insertLogItem('before', 'user-a', '2024-01-04'),
+      insertLogItem('start', 'user-a', '2024-01-05'),
+      insertLogItem('middle', 'user-a', '2024-01-07'),
+      insertLogItem('end', 'user-a', '2024-01-11'),
+      insertLogItem('after', 'user-a', '2024-01-12'),
+    ]);
+
+    const ids = await fetchItems('user-a', 'from=2024-01-05&to=2024-01-11');
+
+    expect(ids.sort()).toEqual(['end', 'middle', 'start']);
+  });
+
+  it('他ユーザーのログは範囲内でも返さない', async () => {
+    await env.DB.batch([
+      insertLogItem('mine', 'user-a', '2024-01-06'),
+      insertLogItem('theirs', 'user-b', '2024-01-06'),
+    ]);
+
+    const ids = await fetchItems('user-a', 'from=2024-01-01&to=2024-01-31');
+
+    expect(ids).toEqual(['mine']);
+  });
+
+  it('timestamp の昇順で返す', async () => {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO log_items (id, user_id, timestamp, log_date, meal_type)
+         VALUES ('later', 'user-a', '2024-01-06T20:00:00Z', '2024-01-06', 'Dinner')`
+      ),
+      env.DB.prepare(
+        `INSERT INTO log_items (id, user_id, timestamp, log_date, meal_type)
+         VALUES ('earlier', 'user-a', '2024-01-06T07:00:00Z', '2024-01-06', 'Breakfast')`
+      ),
+    ]);
+
+    const ids = await fetchItems('user-a', 'from=2024-01-06&to=2024-01-06');
+
+    expect(ids).toEqual(['earlier', 'later']);
+  });
+});

--- a/cloudflare/src/routes/logItems.ts
+++ b/cloudflare/src/routes/logItems.ts
@@ -56,6 +56,8 @@ const logItems = new Hono<{ Bindings: Bindings; Variables: Variables }>()
   .get('/', async (c) => {
     const userId = c.get('userId');
     const logDate = c.req.query('logDate');
+    const from = c.req.query('from');
+    const to = c.req.query('to');
     const limit = parseInt(c.req.query('limit') ?? '0');
     const offset = parseInt(c.req.query('offset') ?? '0');
 
@@ -63,6 +65,12 @@ const logItems = new Hono<{ Bindings: Bindings; Variables: Variables }>()
       const { results } = await c.env.DB.prepare(
         `${JOIN_SELECT} WHERE li.user_id = ? AND li.log_date = ? ORDER BY li.timestamp ASC`
       ).bind(userId, logDate).all<LogItemJoinRow>();
+      const items = results.map(row => logItemToResponse(row, rowToFm(row)));
+      return c.json({ items });
+    } else if (from && to) {
+      const { results } = await c.env.DB.prepare(
+        `${JOIN_SELECT} WHERE li.user_id = ? AND li.log_date >= ? AND li.log_date <= ? ORDER BY li.timestamp ASC`
+      ).bind(userId, from, to).all<LogItemJoinRow>();
       const items = results.map(row => logItemToResponse(row, rowToFm(row)));
       return c.json({ items });
     } else {


### PR DESCRIPTION
Closes #112

## なぜ (Why)

1日単位の集計しか見られず、日をまたいだ傾向・平均・目標達成状況が把握できなかった。記録のモチベーションと食生活の改善判断のために、週/月/カスタム期間で振り返れる統計タブを新設する。

## 変更内容

### iOS
- **`StatisticsView.swift`（新規）**: 期間セレクタ（週/月/カスタム）＋4統計
  1. **推移**: Swift Charts の棒グラフ。指標切替（カロリー/P/F/C）＋目標ラインを破線表示
  2. **1日平均と達成率**: 既存 `CalorieRingView`/`MacroBarView` を再利用。「目標達成日数 / 記録日数」も表示
  3. **PFCバランス**: エネルギー比のドーナツグラフ（`SectorMark`）＋凡例%
  4. **食事タイプ別**: 朝昼夕間食ごとのカロリーを横バーで比較
- **`ContentView.swift`**: 3つ目の「統計」タブ（`chart.bar.xaxis`）を追加
- **`APIClient.swift`**: `fetchLogItems(from:to:)` を追加
- ローカライズ（ja/en）に統計関連の文字列を追加

### バックエンド (cloudflare)
- **`logItems.ts`**: `GET /api/log-items` に `from`/`to` 期間範囲クエリを追加（両端含む・timestamp昇順）
- **`logItems.test.ts`（新規）**: 範囲取得のテスト（TDD: Red→Green）

## テスト

- `cd cloudflare && npm test` → 全38テスト通過
- iOS: `xcodebuild`（iPhone 16 / iOS 18.2 sim）で BUILD SUCCEEDED

## デプロイ注意

⚠️ **Worker を先にデプロイする必要あり**。範囲クエリが本番に無いと統計取得が空になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)