### PR TITLE
feat: 統計タブのUI改善と栄養数値の小数桁統一

### DIFF
--- a/BiteLog/Resources/en.lproj/Localizable.strings
+++ b/BiteLog/Resources/en.lproj/Localizable.strings
@@ -196,7 +196,10 @@
 "Week" = "Week";
 "Month" = "Month";
 "Year" = "Year";
+"Day" = "Day";
 "Custom" = "Custom";
+"Average" = "Average";
+"Total" = "Total";
 "From" = "From";
 "To" = "To";
 "Trend" = "Trend";

--- a/BiteLog/Resources/ja.lproj/Localizable.strings
+++ b/BiteLog/Resources/ja.lproj/Localizable.strings
@@ -210,7 +210,10 @@
 "Week" = "週";
 "Month" = "月";
 "Year" = "年";
+"Day" = "日";
 "Custom" = "カスタム";
+"Average" = "平均";
+"Total" = "合計";
 "From" = "開始";
 "To" = "終了";
 "Trend" = "推移";

--- a/BiteLog/Utilities/NutritionFormatter.swift
+++ b/BiteLog/Utilities/NutritionFormatter.swift
@@ -4,23 +4,16 @@ import Foundation
 enum NutritionFormatter {
   /// 栄養成分の値を適応的にフォーマットします
   /// - 整数値の場合: 小数点なし (例: "1")
-  /// - 小数点1桁で収まる場合: 1桁表示 (例: "1.5")
-  /// - それ以外の場合: 3桁表示 (例: "1.234")
+  /// - それ以外の場合: 小数点1桁表示 (例: "1.5"、"1.234" → "1.2")
   ///
   /// - Parameter value: フォーマットする数値
   /// - Returns: フォーマットされた文字列
   static func formatNutrition(_ value: Double) -> String {
-    // 整数値の場合
+    // 整数値の場合は小数点なし、それ以外は最大1桁に丸める
     if value.truncatingRemainder(dividingBy: 1) == 0 {
       return String(format: "%.0f", value)
-    }
-    // 小数点1桁で収まる場合
-    else if value * 10 == (value * 10).rounded() {
+    } else {
       return String(format: "%.1f", value)
-    }
-    // それ以外は3桁表示
-    else {
-      return String(format: "%.3f", value)
     }
   }
 }

--- a/BiteLog/Utilities/StatisticsCalculator.swift
+++ b/BiteLog/Utilities/StatisticsCalculator.swift
@@ -26,6 +26,50 @@ enum StatisticsCalculator {
   static let netCarbsKcal = 4.0
   static let fiberKcal = 2.0
 
+  /// 日別系列を週/月などのバケットに集計し直す（トレンドグラフの単位切替用）。
+  /// 各バケットの代表日は期間先頭（月なら1日、週なら週初め）。`average` のときは
+  /// バケットの**暦日数**で割った日平均（記録のない日は0扱い。1日平均カードと定義を揃える）、
+  /// それ以外は合計を返す。日付昇順。
+  /// - Parameter component: グルーピング単位（`.weekOfYear` / `.month`）。
+  static func bucketed(
+    _ daily: [DailyNutrition], by component: Calendar.Component,
+    average: Bool, calendar: Calendar
+  ) -> [DailyNutrition] {
+    let groups = Dictionary(grouping: daily) { d -> String in
+      guard let date = bucketFormatter.date(from: d.date),
+        let start = calendar.dateInterval(of: component, for: date)?.start
+      else { return d.date }
+      return bucketFormatter.string(from: start)
+    }
+    return groups.map { key, days in
+      let sum = days.reduce(NutritionValues.zero) { $0 + $1.values }
+      let values: NutritionValues
+      if average {
+        // バケットの暦日数（週=7、月=その月の日数）で割る。記録の無い日も母数に含める。
+        let start = bucketFormatter.date(from: key)
+        let calendarDays = start.flatMap {
+          calendar.range(of: .day, in: component, for: $0)?.count
+        } ?? days.count
+        let n = Double(max(calendarDays, 1))
+        values = NutritionValues(
+          calories: sum.calories / n, netCarbs: sum.netCarbs / n,
+          dietaryFiber: sum.dietaryFiber / n, fat: sum.fat / n, protein: sum.protein / n)
+      } else {
+        values = sum
+      }
+      return DailyNutrition(date: key, values: values)
+    }
+    .sorted { $0.date < $1.date }
+  }
+
+  private static let bucketFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.calendar = Calendar(identifier: .gregorian)
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd"
+    return f
+  }()
+
   /// 日別合計。logDate でグルーピングし、各日の `NutritionValues` を合算。日付昇順で返す。
   static func dailyTotals(_ items: [some NutritionContributing]) -> [DailyNutrition] {
     let grouped = Dictionary(grouping: items, by: { $0.logDate })

--- a/BiteLog/Views/CommonComponents.swift
+++ b/BiteLog/Views/CommonComponents.swift
@@ -2,19 +2,21 @@ import SwiftUI
 
 // カードビュー
 struct CardView<Content: View>: View {
-  let title: String
+  let title: String?
   let content: Content
 
-  init(title: String, @ViewBuilder content: () -> Content) {
+  init(title: String? = nil, @ViewBuilder content: () -> Content) {
     self.title = title
     self.content = content()
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
-      Text(title)
-        .font(.headline)
-        .foregroundColor(.primary)
+    VStack(alignment: .leading, spacing: title == nil ? 0 : 16) {
+      if let title {
+        Text(title)
+          .font(.headline)
+          .foregroundColor(.primary)
+      }
 
       content
     }

--- a/BiteLog/Views/ContentView.swift
+++ b/BiteLog/Views/ContentView.swift
@@ -248,7 +248,6 @@ struct NutrientRow: View {
   let label: String
   let value: Double
   let unit: String
-  let format: String
   let icon: String
   let color: Color
 

--- a/BiteLog/Views/DayContentView.swift
+++ b/BiteLog/Views/DayContentView.swift
@@ -141,7 +141,7 @@ struct DayContentView: View {
 
       NutrientRow(
         label: NSLocalizedString("Carbs (Sugar + Fiber)", comment: "Nutrient label"),
-        value: dailyTotals.carbs, unit: "g", format: "%.3f",
+        value: dailyTotals.carbs, unit: "g",
         icon: "c.circle.fill", color: .gray
       )
       .padding(.vertical, 8)

--- a/BiteLog/Views/EditItemView.swift
+++ b/BiteLog/Views/EditItemView.swift
@@ -122,20 +122,20 @@ struct EditItemView: View {
                     foodMaster?.portionUnit ?? item.portionUnit))
                   .font(.caption).foregroundColor(.secondary).padding(.bottom, 4)
 
-                  EditNutrientRow(icon: "flame.fill", iconColor: .orange, label: NSLocalizedString("Calories", comment: "Nutrient label"), value: String(format: "%.2f", perPortionCalories), totalValue: totalCalories, unit: "kcal")
-                  EditNutrientRow(icon: "p.circle.fill", iconColor: .blue, label: NSLocalizedString("Protein", comment: "Nutrient label"), value: String(format: "%.2f", perPortionProtein), totalValue: totalProtein, unit: "g")
-                  EditNutrientRow(icon: "f.circle.fill", iconColor: .yellow, label: NSLocalizedString("Fat", comment: "Nutrient label"), value: String(format: "%.2f", perPortionFat), totalValue: totalFat, unit: "g")
-                  EditNutrientRow(icon: "c.circle.fill", iconColor: .green, label: NSLocalizedString("Sugar", comment: "Nutrient label"), value: String(format: "%.2f", perPortionNetCarbs), totalValue: totalNetCarbs, unit: "g")
-                  EditNutrientRow(icon: "leaf.circle.fill", iconColor: .brown, label: NSLocalizedString("Dietary Fiber", comment: "Nutrient label"), value: String(format: "%.2f", perPortionDietaryFiber), totalValue: totalDietaryFiber, unit: "g")
+                  EditNutrientRow(icon: "flame.fill", iconColor: .orange, label: NSLocalizedString("Calories", comment: "Nutrient label"), value: NutritionFormatter.formatNutrition(perPortionCalories), totalValue: totalCalories, unit: "kcal")
+                  EditNutrientRow(icon: "p.circle.fill", iconColor: .blue, label: NSLocalizedString("Protein", comment: "Nutrient label"), value: NutritionFormatter.formatNutrition(perPortionProtein), totalValue: totalProtein, unit: "g")
+                  EditNutrientRow(icon: "f.circle.fill", iconColor: .yellow, label: NSLocalizedString("Fat", comment: "Nutrient label"), value: NutritionFormatter.formatNutrition(perPortionFat), totalValue: totalFat, unit: "g")
+                  EditNutrientRow(icon: "c.circle.fill", iconColor: .green, label: NSLocalizedString("Sugar", comment: "Nutrient label"), value: NutritionFormatter.formatNutrition(perPortionNetCarbs), totalValue: totalNetCarbs, unit: "g")
+                  EditNutrientRow(icon: "leaf.circle.fill", iconColor: .brown, label: NSLocalizedString("Dietary Fiber", comment: "Nutrient label"), value: NutritionFormatter.formatNutrition(perPortionDietaryFiber), totalValue: totalDietaryFiber, unit: "g")
 
                   HStack {
                     Image(systemName: "c.circle.fill").foregroundColor(.gray).frame(width: 24)
                     Text(NSLocalizedString("Carbs (Sugar + Fiber)", comment: "Nutrient label")).foregroundColor(.secondary)
                     Spacer()
-                    Text(String(format: "%.2f", perPortionNetCarbs + perPortionDietaryFiber)).foregroundColor(.secondary)
+                    Text(NutritionFormatter.formatNutrition(perPortionNetCarbs + perPortionDietaryFiber)).foregroundColor(.secondary)
                     Text("g").foregroundColor(.secondary).frame(width: 20, alignment: .leading)
                     Text("→").foregroundColor(.secondary).padding(.horizontal, 4)
-                    Text(String(format: "%.2f", totalCarbs)).foregroundColor(.secondary)
+                    Text(NutritionFormatter.formatNutrition(totalCarbs)).foregroundColor(.secondary)
                     Text("g").foregroundColor(.secondary)
                   }
                   .padding(.vertical, 12).padding(.horizontal, 12)
@@ -204,7 +204,7 @@ struct EditNutrientRow: View {
       Text(value.isEmpty ? "0" : value).multilineTextAlignment(.trailing)
       Text(unit).foregroundColor(.secondary).frame(width: unit == "kcal" ? 40 : 20, alignment: .leading)
       Text("→").foregroundColor(.secondary).padding(.horizontal, 4)
-      Text(String(format: "%.2f", totalValue)).foregroundColor(.primary)
+      Text(NutritionFormatter.formatNutrition(totalValue)).foregroundColor(.primary)
       Text(unit).foregroundColor(.secondary)
     }
     .padding(.vertical, 12).padding(.horizontal, 12)

--- a/BiteLog/Views/StatisticsView.swift
+++ b/BiteLog/Views/StatisticsView.swift
@@ -63,6 +63,57 @@ enum TrendMetric: String, CaseIterable, Identifiable {
   }
 }
 
+/// トレンドの下でセグメント切替する詳細セクション。選択中のカードのみ描画する。
+enum StatSection: String, CaseIterable, Identifiable {
+  case average, pfc, mealType
+  var id: String { rawValue }
+
+  var localizedName: String {
+    switch self {
+    case .average: return NSLocalizedString("Daily Average", comment: "Statistics section")
+    case .pfc: return NSLocalizedString("PFC Balance", comment: "Statistics section")
+    case .mealType: return NSLocalizedString("By Meal Type", comment: "Statistics section")
+    }
+  }
+}
+
+/// トレンドグラフの集計単位（X軸の1点が表す期間）。
+/// 年単位は複数年を映す期間が無く棒が1本になるため一旦持たない。
+enum StatBucket: String, CaseIterable, Identifiable {
+  case day, week, month
+  var id: String { rawValue }
+
+  var localizedName: String {
+    switch self {
+    case .day: return NSLocalizedString("Day", comment: "Trend bucket")
+    case .week: return NSLocalizedString("Week", comment: "Statistics period")
+    case .month: return NSLocalizedString("Month", comment: "Statistics period")
+    }
+  }
+
+  /// グルーピングに使う暦単位。`.day` は集計せず日次のまま表示するため nil。
+  var component: Calendar.Component? {
+    switch self {
+    case .day: return nil
+    case .week: return .weekOfYear
+    case .month: return .month
+    }
+  }
+}
+
+/// バケット内の集計方法。
+enum StatAggregation: String, CaseIterable, Identifiable {
+  case average, total
+  var id: String { rawValue }
+
+  var localizedName: String {
+    switch self {
+    case .average: return NSLocalizedString("Average", comment: "Aggregation")
+    case .total: return NSLocalizedString("Total", comment: "Aggregation")
+    }
+  }
+}
+
 // MARK: - 日付ユーティリティ
 
 private enum StatDate {
@@ -86,6 +137,9 @@ struct StatisticsView: View {
 
   @State private var period: StatPeriod = .week
   @State private var metric: TrendMetric = .calories
+  @State private var section: StatSection = .average
+  @State private var bucket: StatBucket = .day
+  @State private var aggregation: StatAggregation = .total
 
   // カスタム期間
   @State private var customFrom: Date = Calendar.current.date(
@@ -122,6 +176,32 @@ struct StatisticsView: View {
 
   private var visibleSeconds: TimeInterval { Double(visibleDays) * 86400 }
 
+  /// period に対して意味のある集計単位だけを出す（棒が1本しか出ない組み合わせを避ける）。
+  private var availableBuckets: [StatBucket] {
+    switch period {
+    case .week: return [.day]
+    case .month: return [.day, .week]
+    case .year: return [.day, .week, .month]
+    case .custom:
+      if visibleDays <= 31 { return [.day, .week] }
+      return [.day, .week, .month]
+    }
+  }
+
+  /// トレンドグラフに描く系列。日次（`trendSeries`）を選択中の単位/集計で丸め直す。
+  private var displayTrendSeries: [DailyNutrition] {
+    guard let component = bucket.component else { return trendSeries }
+    return StatisticsCalculator.bucketed(
+      trendSeries, by: component, average: aggregation == .average, calendar: cal)
+  }
+
+  /// カロリー目標線。合計バケットでは日次目標と比較できないため出さない。
+  private var trendGoalLine: Double? {
+    guard metric == .calories else { return nil }
+    if bucket != .day && aggregation == .total { return nil }
+    return nutritionGoalsManager.targetCalories
+  }
+
   /// カードが集計対象とする期間 [from, to]（両端の日付）。スクロール停止時の位置。
   private var settledRange: (from: Date, to: Date) {
     let from = cal.startOfDay(for: settledScrollX)
@@ -137,7 +217,7 @@ struct StatisticsView: View {
 
   var body: some View {
     ScrollView {
-      VStack(spacing: 16) {
+      VStack(spacing: 10) {
         periodSelector
 
         if isLoading {
@@ -146,19 +226,26 @@ struct StatisticsView: View {
         } else if loadFailed {
           errorView
         } else {
-          visibleRangeLabel
+          dateNavigationBar
           trendCard
-          averageCard
-          pfcBalanceCard
-          mealTypeCard
+          sectionSelector
+          switch section {
+          case .average: averageCard
+          case .pfc: pfcBalanceCard
+          case .mealType: mealTypeCard
+          }
         }
       }
       .padding()
     }
     .background(Color(UIColor.systemGroupedBackground))
-    .navigationTitle(NSLocalizedString("Statistics", comment: "Tab name"))
-    .navigationBarTitleDisplayMode(.inline)
+    // 下部タブバーに「統計」ラベルがあり重複するため、上部ナビバーは隠して縦幅を確保。
+    .toolbar(.hidden, for: .navigationBar)
     .task(id: reloadKey) { await reload() }
+    .onChange(of: period) { _, _ in
+      // period を変えると使えない単位が出るので、対象外なら日次に戻す。
+      if !availableBuckets.contains(bucket) { bucket = .day }
+    }
   }
 
   // task(id:) が変わったら全リセット＆再取得
@@ -169,7 +256,7 @@ struct StatisticsView: View {
   // MARK: - 期間セレクタ
 
   private var periodSelector: some View {
-    VStack(spacing: 12) {
+    VStack(spacing: 8) {
       Picker("", selection: $period) {
         ForEach(StatPeriod.allCases) { p in
           Text(p.localizedName).tag(p)
@@ -196,16 +283,59 @@ struct StatisticsView: View {
     }
   }
 
-  private var visibleRangeLabel: some View {
+  /// 期間ラベルの両サイドに前後ページ送りの矢印を備えたナビゲーションバー。
+  private var dateNavigationBar: some View {
     let f = DateFormatter()
     f.locale = languageManager.locale
     f.dateStyle = .medium
     f.timeStyle = .none
     let text = "\(f.string(from: settledRange.from)) – \(f.string(from: settledRange.to))"
-    return Text(text)
-      .font(.subheadline.weight(.medium))
-      .foregroundColor(.secondary)
-      .frame(maxWidth: .infinity, alignment: .leading)
+    // 進む側は最新の可視期間（左端が today-(visibleDays-1)）に達したら無効化
+    let latestFrom = cal.date(
+      byAdding: .day, value: -(visibleDays - 1), to: cal.startOfDay(for: Date())) ?? Date()
+    let atLatest = settledRange.from >= latestFrom
+
+    return HStack {
+      Button { page(by: -visibleDays) } label: {
+        Image(systemName: "chevron.left").font(.body.weight(.semibold))
+      }
+      .disabled(period == .custom)
+
+      Spacer()
+      Text(text)
+        .font(.subheadline.weight(.medium))
+        .foregroundColor(.secondary)
+      Spacer()
+
+      Button { page(by: visibleDays) } label: {
+        Image(systemName: "chevron.right").font(.body.weight(.semibold))
+      }
+      .disabled(period == .custom || atLatest)
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  /// 表示するセクションを選ぶセグメント。選択中のカードだけを描画する。
+  private var sectionSelector: some View {
+    Picker("", selection: $section) {
+      ForEach(StatSection.allCases) { s in
+        Text(s.localizedName).tag(s)
+      }
+    }
+    .pickerStyle(.segmented)
+  }
+
+  /// 可視期間を deltaDays 分ずらす。進む側は今日を超えないようクランプし、
+  /// 戻る側は既存の無限スクロール機構でバッファを拡張する。custom は固定範囲のため無効。
+  private func page(by deltaDays: Int) {
+    guard period != .custom else { return }
+    let candidate = cal.date(byAdding: .day, value: deltaDays, to: settledScrollX) ?? settledScrollX
+    let latestFrom = cal.date(
+      byAdding: .day, value: -(visibleDays - 1), to: cal.startOfDay(for: Date())) ?? Date()
+    settledScrollX = min(cal.startOfDay(for: candidate), latestFrom)
+    if shouldLoadMore(at: settledScrollX) {
+      Task { await loadMoreIfNeeded() }
+    }
   }
 
   private var errorView: some View {
@@ -225,8 +355,8 @@ struct StatisticsView: View {
   // MARK: - ① 期間トレンド（無限横スクロール）
 
   private var trendCard: some View {
-    CardView(title: NSLocalizedString("Trend", comment: "Statistics section")) {
-      VStack(alignment: .leading, spacing: 12) {
+    CardView {
+      VStack(alignment: .leading, spacing: 10) {
         Picker("", selection: $metric) {
           ForEach(TrendMetric.allCases) { m in
             Text(m.localizedName).tag(m)
@@ -234,14 +364,35 @@ struct StatisticsView: View {
         }
         .pickerStyle(.segmented)
 
+        HStack(spacing: 8) {
+          Picker("", selection: $bucket) {
+            ForEach(availableBuckets) { b in
+              Text(b.localizedName).tag(b)
+            }
+          }
+          .pickerStyle(.segmented)
+
+          if bucket != .day {
+            Picker("", selection: $aggregation) {
+              ForEach(StatAggregation.allCases) { a in
+                Text(a.localizedName).tag(a)
+              }
+            }
+            .pickerStyle(.segmented)
+            .fixedSize()
+          }
+        }
+
         TrendChartView(
-          series: trendSeries,
+          series: displayTrendSeries,
           metric: metric,
+          bucket: bucket,
           visibleDays: visibleDays,
           visibleSeconds: visibleSeconds,
-          goalLine: metric == .calories ? nutritionGoalsManager.targetCalories : nil,
+          goalLine: trendGoalLine,
           xAxisStride: xAxisStride,
           initialScrollX: settledScrollX,
+          scrollTarget: settledScrollX,
           onScroll: { x in
             // 同期・軽量: 境界に近いときだけ追加取得を起動（毎ティック Task 生成を回避）。
             if shouldLoadMore(at: x) {
@@ -271,7 +422,7 @@ struct StatisticsView: View {
     let achieved = StatisticsCalculator.goalAchievedDays(
       settledItems, targetCalories: nutritionGoalsManager.targetCalories)
 
-    return CardView(title: NSLocalizedString("Daily Average", comment: "Statistics section")) {
+    return CardView {
       VStack(spacing: 16) {
         HStack(alignment: .center, spacing: 20) {
           CalorieRingView(
@@ -317,7 +468,7 @@ struct StatisticsView: View {
   private var pfcBalanceCard: some View {
     let balance = StatisticsCalculator.pfcBalance(settledItems)
 
-    return CardView(title: NSLocalizedString("PFC Balance", comment: "Statistics section")) {
+    return CardView {
       VStack(spacing: 12) {
         GeometryReader { geo in
           HStack(spacing: 0) {
@@ -361,15 +512,16 @@ struct StatisticsView: View {
     }
     let maxCal = rows.map { $0.values.calories }.max() ?? 0
 
-    return CardView(title: NSLocalizedString("By Meal Type", comment: "Statistics section")) {
+    return CardView {
       VStack(alignment: .leading, spacing: 16) {
-        // 期間合計
+        // 期間合計（ラベルと数値を1行に）
         VStack(alignment: .leading, spacing: 6) {
-          Text(NSLocalizedString("Period Total", comment: "Statistics metric"))
-            .font(.caption).foregroundColor(.secondary)
           HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(NSLocalizedString("Period Total", comment: "Statistics metric"))
+              .font(.caption).foregroundColor(.secondary)
+            Spacer()
             Text(NutritionFormatter.formatNutrition(total.calories))
-              .font(.system(size: 24, weight: .bold, design: .rounded))
+              .font(.system(size: 20, weight: .bold, design: .rounded))
             Text("kcal").font(.subheadline).foregroundColor(.secondary)
           }
           HStack(spacing: 6) {
@@ -503,11 +655,14 @@ struct StatisticsView: View {
 private struct TrendChartView: View {
   let series: [DailyNutrition]
   let metric: TrendMetric
+  let bucket: StatBucket
   let visibleDays: Int
   let visibleSeconds: TimeInterval
   let goalLine: Double?
   let xAxisStride: Int
   let initialScrollX: Date
+  /// 矢印操作など外部からの一方向ジャンプ先。ライブスクロールには関与しない。
+  let scrollTarget: Date
   let onScroll: (Date) -> Void
   let onScrollSettled: (Date) -> Void
 
@@ -515,43 +670,85 @@ private struct TrendChartView: View {
   @State private var settleTask: Task<Void, Never>?
 
   init(
-    series: [DailyNutrition], metric: TrendMetric, visibleDays: Int, visibleSeconds: TimeInterval,
-    goalLine: Double?, xAxisStride: Int, initialScrollX: Date,
-    onScroll: @escaping (Date) -> Void, onScrollSettled: @escaping (Date) -> Void
+    series: [DailyNutrition], metric: TrendMetric, bucket: StatBucket, visibleDays: Int,
+    visibleSeconds: TimeInterval, goalLine: Double?, xAxisStride: Int, initialScrollX: Date,
+    scrollTarget: Date, onScroll: @escaping (Date) -> Void, onScrollSettled: @escaping (Date) -> Void
   ) {
     self.series = series
     self.metric = metric
+    self.bucket = bucket
     self.visibleDays = visibleDays
     self.visibleSeconds = visibleSeconds
     self.goalLine = goalLine
     self.xAxisStride = xAxisStride
     self.initialScrollX = initialScrollX
+    self.scrollTarget = scrollTarget
     self.onScroll = onScroll
     self.onScrollSettled = onScrollSettled
     _scrollX = State(initialValue: initialScrollX)
   }
 
-  // 長期間（月/年）は点を省き直線補間にして描画コストを抑える。
+  // 長期間（月/年）は点を省き直線補間にして描画コストを抑える。日次表示のみ対象。
   private var simplified: Bool { visibleDays > 60 }
+
+  // 棒グラフの1本が占める暦単位。
+  private var barUnit: Calendar.Component {
+    switch bucket {
+    case .day: return .day
+    case .week: return .weekOfYear
+    case .month: return .month
+    }
+  }
+
+  private var axisStrideComponent: Calendar.Component {
+    switch bucket {
+    case .day: return visibleDays > 60 ? .month : .day
+    case .week: return .weekOfYear
+    case .month: return .month
+    }
+  }
+
+  private var axisStrideCount: Int {
+    switch bucket {
+    case .day: return xAxisStride
+    case .week: return max(visibleDays / 7 / 6, 1)
+    case .month: return 1
+    }
+  }
+
+  private var axisLabelFormat: Date.FormatStyle {
+    switch bucket {
+    case .day, .week: return .dateTime.month(.abbreviated).day()
+    case .month: return .dateTime.month(.abbreviated)
+    }
+  }
 
   var body: some View {
     Chart {
       ForEach(series) { day in
         if let date = StatDate.date(day.date) {
-          LineMark(
-            x: .value("Date", date, unit: .day),
-            y: .value(metric.localizedName, metric.value(day.values))
-          )
-          .foregroundStyle(metric.color)
-          .interpolationMethod(simplified ? .linear : .catmullRom)
-
-          if !simplified {
-            PointMark(
+          if bucket == .day {
+            LineMark(
               x: .value("Date", date, unit: .day),
               y: .value(metric.localizedName, metric.value(day.values))
             )
             .foregroundStyle(metric.color)
-            .symbolSize(28)
+            .interpolationMethod(simplified ? .linear : .catmullRom)
+
+            if !simplified {
+              PointMark(
+                x: .value("Date", date, unit: .day),
+                y: .value(metric.localizedName, metric.value(day.values))
+              )
+              .foregroundStyle(metric.color)
+              .symbolSize(28)
+            }
+          } else {
+            BarMark(
+              x: .value("Date", date, unit: barUnit),
+              y: .value(metric.localizedName, metric.value(day.values))
+            )
+            .foregroundStyle(metric.color)
           }
         }
       }
@@ -565,13 +762,13 @@ private struct TrendChartView: View {
     .chartXVisibleDomain(length: visibleSeconds)
     .chartScrollPosition(x: $scrollX)
     .chartXAxis {
-      AxisMarks(values: .stride(by: visibleDays > 60 ? .month : .day, count: xAxisStride)) { _ in
+      AxisMarks(values: .stride(by: axisStrideComponent, count: axisStrideCount)) { _ in
         AxisGridLine()
         AxisTick()
-        AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+        AxisValueLabel(format: axisLabelFormat)
       }
     }
-    .frame(height: 200)
+    .frame(height: 170)
     .onChange(of: scrollX) { _, x in
       onScroll(x)  // 同期・軽量（境界近傍のみ追加取得を起動）
       // デバウンス: 停止後にのみカード集計を更新する
@@ -579,6 +776,14 @@ private struct TrendChartView: View {
       settleTask = Task {
         try? await Task.sleep(for: .milliseconds(150))
         if !Task.isCancelled { onScrollSettled(x) }
+      }
+    }
+    .onChange(of: scrollTarget) { _, target in
+      // 矢印操作など外部からのジャンプ。日単位で差があるときのみ反映し、
+      // onScrollSettled 経由の帰還ループを防ぐ。
+      let cal = Calendar.current
+      if !cal.isDate(target, inSameDayAs: scrollX) {
+        withAnimation { scrollX = target }
       }
     }
   }


### PR DESCRIPTION
## 背景 / Why
栄養数値が一部で小数点2〜3桁まで表示されて見づらく、統計タブはカードが縦に連なって1画面に収まらず、期間ごとの内訳を確認するのにスクロールが必要だった。表示まわりをまとめて改善する。

## 変更点
### 栄養数値の小数桁統一（最大1桁）
- `NutritionFormatter.formatNutrition` の3桁分岐を廃止し「整数→小数なし／それ以外→1桁」に
- `EditItemView` の固定 `%.2f` を共通フォーマッタに置換
- `NutrientRow` の未使用 `format` 引数を削除（`DayContentView` の `%.3f` 指定も除去）

### 統計タブの再構成
- トレンドを常時表示し、その下に **平均 / PFC / 食事別** をセグメント切替（一度に1カード）
- 期間ラベルの両サイドに `< >` のページ送りを追加（チャートのスクロール位置と同期。custom は無効、未来側はクランプ）

### トレンドの集計単位
- **日 / 週 / 月** の単位と **平均 / 合計** を追加。指標はトレンドの選択（カロリー/P/F/C）に追従
- 日＝折れ線、週/月＝棒グラフ。平均は暦日数基準で1日平均カードと定義を統一
- period に応じて意味のある単位だけ提示（週=日 / 月=日・週 / 年=日・週・月）。年単位は一旦撤去
- バケット集計はクライアント側（重い日次集計は既存どおりSQL集計）

### 縦幅の圧縮
- 下部タブバーと重複する上部ナビバーを非表示
- `CardView` をタイトル省略可能にし、統計カードの見出しを撤去
- 「Period Total」を1行化、各所の行間を圧縮

## 確認
- `xcodebuild ... CODE_SIGNING_ALLOWED=NO build` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)