### PR TITLE
feat: 体組成計測データ機能（CSV一括 + 手動追加）

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,8 +7,9 @@ import FoodMasterPage from '@/pages/FoodMasterPage';
 import MealLogPage from '@/pages/MealLogPage';
 import NutritionGoalsPage from '@/pages/NutritionGoalsPage';
 import StatisticsPage from '@/pages/StatisticsPage';
+import BodyMeasurementPage from '@/pages/BodyMeasurementPage';
 
-type Tab = 'food' | 'log' | 'goals' | 'stats';
+type Tab = 'food' | 'log' | 'goals' | 'stats' | 'body';
 
 export default function App() {
   const [session, setSession] = useState(getSession());
@@ -41,6 +42,7 @@ export default function App() {
         {activeTab === 'log'   && <MealLogPage onToast={addToast} />}
         {activeTab === 'goals' && <NutritionGoalsPage onToast={addToast} />}
         {activeTab === 'stats' && <StatisticsPage onToast={addToast} />}
+        {activeTab === 'body'  && <BodyMeasurementPage onToast={addToast} />}
       </main>
       <Toast toasts={toasts} onRemove={removeToast} />
     </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 import { clearSession } from '@/lib/auth';
 
-type Tab = 'food' | 'log' | 'goals' | 'stats';
+type Tab = 'food' | 'log' | 'goals' | 'stats' | 'body';
 
 interface Props {
   activeTab: Tab;
@@ -15,6 +15,7 @@ const tabs: { id: Tab; label: string; icon: string }[] = [
   { id: 'log',   label: 'MEAL LOG',    icon: '◉' },
   { id: 'goals', label: 'NUTRITION',   icon: '◇' },
   { id: 'stats', label: 'STATISTICS',  icon: '◎' },
+  { id: 'body',  label: 'BODY',        icon: '◐' },
 ];
 
 export default function Sidebar({ activeTab, onTabChange, onLogout, isAdmin }: Props) {

--- a/apps/web/src/hooks/useBodyMeasurements.ts
+++ b/apps/web/src/hooks/useBodyMeasurements.ts
@@ -1,0 +1,39 @@
+import useSWR from 'swr';
+import { createClient } from '@/lib/api';
+
+/** API の /body-measurements が返す体組成計測データ（CSV全17列）。 */
+export interface BodyMeasurement {
+  id: string;
+  sourceDate: string | null;
+  measuredAt: string;
+  measurementDateRaw: string | null;
+  measurementTimeRaw: string | null;
+  measurementIndex: number | null;
+  itemCount: number | null;
+  inputMethod: string | null;
+  weightKg: number | null;
+  bodyFatPercent: number | null;
+  muscleMassKg: number | null;
+  muscleScore: number | null;
+  visceralFatLevel: number | null;
+  basalMetabolismKcal: number | null;
+  metabolicAge: number | null;
+  boneMassKg: number | null;
+  bodyWaterPercent: number | null;
+  pageUrl: string | null;
+}
+
+async function fetchBodyMeasurements(): Promise<BodyMeasurement[]> {
+  const res = await createClient().api['body-measurements'].$get();
+  if (!res.ok) throw new Error('body-measurements');
+  const data = await res.json();
+  return data.items as BodyMeasurement[];
+}
+
+/** 体組成計測データ一覧（measured_at 降順）。 */
+export function useBodyMeasurements(onError?: () => void) {
+  return useSWR<BodyMeasurement[]>('body-measurements', fetchBodyMeasurements, {
+    revalidateOnFocus: false,
+    onError,
+  });
+}

--- a/apps/web/src/pages/BodyMeasurementPage.tsx
+++ b/apps/web/src/pages/BodyMeasurementPage.tsx
@@ -1,0 +1,267 @@
+import { useState, useCallback, useRef } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { createClient } from '@/lib/api';
+import type { ToastMessage } from '@/components/Toast';
+import { useBodyMeasurements, type BodyMeasurement } from '@/hooks/useBodyMeasurements';
+
+interface Props {
+  onToast: (msg: Omit<ToastMessage, 'id'>) => void;
+}
+
+// 手動追加フォーム。measuredAt は datetime-local、その他は任意の数値。
+const emptyForm = {
+  measuredAt: '',
+  weightKg: '',
+  bodyFatPercent: '',
+  muscleMassKg: '',
+  muscleScore: '',
+  visceralFatLevel: '',
+  basalMetabolismKcal: '',
+  metabolicAge: '',
+  boneMassKg: '',
+  bodyWaterPercent: '',
+};
+type FormData = typeof emptyForm;
+
+const numFields: { key: keyof FormData; label: string; step?: string }[] = [
+  { key: 'weightKg',            label: '体重 (kg)',        step: '0.1' },
+  { key: 'bodyFatPercent',      label: '体脂肪率 (%)',     step: '0.1' },
+  { key: 'muscleMassKg',        label: '筋肉量 (kg)',      step: '0.1' },
+  { key: 'muscleScore',         label: '筋肉スコア',       step: '1' },
+  { key: 'visceralFatLevel',    label: '内臓脂肪レベル',   step: '0.5' },
+  { key: 'basalMetabolismKcal', label: '基礎代謝 (kcal)',  step: '1' },
+  { key: 'metabolicAge',        label: '体内年齢',         step: '1' },
+  { key: 'boneMassKg',          label: '推定骨量 (kg)',    step: '0.1' },
+  { key: 'bodyWaterPercent',    label: '体水分率 (%)',     step: '0.1' },
+];
+
+function fmtDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function num(v: number | null): string {
+  return v == null ? '—' : String(v);
+}
+
+export default function BodyMeasurementPage({ onToast }: Props) {
+  const onError = useCallback(
+    () => onToast({ message: 'データの取得に失敗しました', type: 'error' }),
+    [onToast]
+  );
+  const { data, isLoading, mutate } = useBodyMeasurements(onError);
+  const items = data ?? [];
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form, setForm] = useState<FormData>(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<BodyMeasurement | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function openAdd() {
+    setForm(emptyForm);
+    setModalOpen(true);
+  }
+
+  function setField<K extends keyof FormData>(key: K, val: FormData[K]) {
+    setForm((f) => ({ ...f, [key]: val }));
+  }
+
+  async function handleSave() {
+    if (!form.measuredAt) {
+      onToast({ message: '計測日時を入力してください', type: 'error' });
+      return;
+    }
+    const measuredAt = new Date(form.measuredAt).toISOString();
+    const sourceDate = measuredAt.slice(0, 10);
+    const payload: Record<string, unknown> = {
+      measuredAt, sourceDate, inputMethod: '手動入力',
+    };
+    for (const f of numFields) {
+      const raw = form[f.key];
+      if (raw !== '') payload[f.key] = Number(raw);
+    }
+
+    setSaving(true);
+    try {
+      const res = await createClient().api['body-measurements'].$post({ json: payload });
+      if (res.status === 409) {
+        onToast({ message: 'その日時の計測データは既に存在します', type: 'error' });
+        return;
+      }
+      if (!res.ok) throw new Error();
+      onToast({ message: '追加しました', type: 'success' });
+      setModalOpen(false);
+      mutate();
+    } catch {
+      onToast({ message: '保存に失敗しました', type: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // 同じファイルを再選択できるようにリセット
+    if (!file) return;
+
+    setImporting(true);
+    try {
+      const csvText = await file.text();
+      const res = await createClient().api['body-measurements'].import.$post(
+        {},
+        { init: { body: csvText, headers: { 'Content-Type': 'text/csv' } } }
+      );
+      if (!res.ok) throw new Error();
+      const { created, skipped } = await res.json();
+      onToast({ message: `${created}件登録（${skipped}件スキップ）`, type: 'success' });
+      mutate();
+    } catch {
+      onToast({ message: 'インポートに失敗しました', type: 'error' });
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  async function handleDelete(item: BodyMeasurement) {
+    try {
+      const res = await createClient().api['body-measurements'][':id'].$delete({ param: { id: item.id } });
+      if (!res.ok) throw new Error();
+      onToast({ message: '削除しました', type: 'success' });
+      setDeleteTarget(null);
+      mutate();
+    } catch {
+      onToast({ message: '削除に失敗しました', type: 'error' });
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border-dim">
+        <div>
+          <h2 className="text-sm font-bold tracking-widest text-neon-cyan text-glow-cyan uppercase">Body Measurements</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">{items.length} records</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <input ref={fileRef} type="file" accept=".csv,text/csv" onChange={handleImport} className="hidden" />
+          <motion.button whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}
+            onClick={() => fileRef.current?.click()} disabled={importing}
+            className="px-4 py-1.5 text-xs font-bold tracking-widest uppercase disabled:opacity-40"
+            style={{ background: 'rgba(0,229,255,0.1)', border: '1px solid #00e5ff', color: '#00e5ff', boxShadow: '0 0 10px rgba(0,229,255,0.2)' }}
+          >{importing ? 'IMPORTING...' : '⇪ IMPORT CSV'}</motion.button>
+          <motion.button whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }} onClick={openAdd}
+            className="px-4 py-1.5 text-xs font-bold tracking-widest uppercase"
+            style={{ background: 'rgba(0,255,65,0.1)', border: '1px solid #00ff41', color: '#00ff41', boxShadow: '0 0 10px rgba(0,255,65,0.2)' }}
+          >+ ADD</motion.button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-xs border-collapse">
+          <thead className="sticky top-0 bg-bg-surface">
+            <tr>
+              {['計測日時', '体重kg', '体脂肪%', '筋肉kg', '内臓脂肪', '基礎代謝', '体内年齢', '体水分%', ''].map((h) => (
+                <th key={h} className="px-4 py-3 text-left text-muted-foreground tracking-widest font-normal border-b border-border-dim">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-muted-foreground tracking-widest">LOADING...</td></tr>
+            ) : items.length === 0 ? (
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-muted-foreground tracking-widest">NO DATA</td></tr>
+            ) : items.map((item) => (
+              <motion.tr key={item.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }}
+                className="border-b border-border-dim hover:bg-neon-cyan/5 transition-colors group"
+              >
+                <td className="px-4 py-3 text-foreground whitespace-nowrap">{fmtDateTime(item.measuredAt)}</td>
+                <td className="px-4 py-3 text-neon-yellow">{num(item.weightKg)}</td>
+                <td className="px-4 py-3 text-neon-magenta">{num(item.bodyFatPercent)}</td>
+                <td className="px-4 py-3 text-neon-green">{num(item.muscleMassKg)}</td>
+                <td className="px-4 py-3 text-neon-cyan">{num(item.visceralFatLevel)}</td>
+                <td className="px-4 py-3 text-muted-foreground">{num(item.basalMetabolismKcal)}</td>
+                <td className="px-4 py-3 text-muted-foreground">{num(item.metabolicAge)}</td>
+                <td className="px-4 py-3 text-muted-foreground">{num(item.bodyWaterPercent)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button onClick={() => setDeleteTarget(item)} className="px-2 py-1 text-xs text-destructive border border-destructive/30 hover:border-destructive hover:bg-destructive/10 transition-all">DEL</button>
+                  </div>
+                </td>
+              </motion.tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <AnimatePresence>
+        {modalOpen && (
+          <Modal title="ADD MEASUREMENT" onClose={() => setModalOpen(false)} onSave={handleSave} saveLabel={saving ? 'SAVING...' : 'SAVE'}>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="計測日時" colSpan={2}>
+                <input type="datetime-local" value={form.measuredAt} onChange={(e) => setField('measuredAt', e.target.value)} className={fc} style={{ fontFamily: 'inherit' }} />
+              </Field>
+              {numFields.map((f) => (
+                <Field key={f.key} label={f.label}>
+                  <input type="number" step={f.step} value={form[f.key]} onChange={(e) => setField(f.key, e.target.value)} className={fc} style={{ fontFamily: 'inherit' }} />
+                </Field>
+              ))}
+            </div>
+          </Modal>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {deleteTarget && (
+          <Modal title="DELETE CONFIRM" onClose={() => setDeleteTarget(null)} onSave={() => handleDelete(deleteTarget)} saveLabel="DELETE" danger>
+            <p className="text-sm text-foreground"><span className="text-neon-cyan">{fmtDateTime(deleteTarget.measuredAt)}</span> の計測データを削除しますか？</p>
+            <p className="text-xs text-muted-foreground mt-2">この操作は取り消せません。</p>
+          </Modal>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+const fc = "w-full bg-bg-card border border-border-dim px-3 py-1.5 text-xs text-foreground focus:outline-none focus:border-neon-cyan transition-colors";
+
+function Field({ label, children, colSpan }: { label: string; children: React.ReactNode; colSpan?: number }) {
+  return (
+    <div className={colSpan === 2 ? 'col-span-2' : ''}>
+      <label className="block text-xs text-muted-foreground mb-1 tracking-wider uppercase">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function Modal({ title, onClose, onSave, saveLabel = 'SAVE', danger = false, children }: {
+  title: string; onClose: () => void; onSave: () => void; saveLabel?: string; danger?: boolean; children: React.ReactNode;
+}) {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-40 p-4" onClick={onClose}
+    >
+      <motion.div initial={{ scale: 0.9, y: 10 }} animate={{ scale: 1, y: 0 }} exit={{ scale: 0.9, y: 10 }}
+        className="w-full max-w-md bg-bg-surface border border-border-dim p-6"
+        style={{ boxShadow: '0 0 40px rgba(0,229,255,0.1)' }} onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-sm font-bold tracking-widest text-neon-cyan">{title}</h3>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">×</button>
+        </div>
+        <div className="mb-6">{children}</div>
+        <div className="flex justify-end gap-3">
+          <button onClick={onClose} className="px-4 py-2 text-xs tracking-widest border border-border-dim text-muted-foreground hover:border-foreground hover:text-foreground transition-all uppercase">CANCEL</button>
+          <motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} onClick={onSave}
+            className="px-4 py-2 text-xs font-bold tracking-widest uppercase"
+            style={{ background: danger ? 'rgba(255,51,102,0.1)' : 'rgba(0,229,255,0.1)', border: `1px solid ${danger ? '#ff3366' : '#00e5ff'}`, color: danger ? '#ff3366' : '#00e5ff', boxShadow: `0 0 10px ${danger ? 'rgba(255,51,102,0.2)' : 'rgba(0,229,255,0.2)'}` }}
+          >{saveLabel}</motion.button>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/apps/web/src/pages/BodyMeasurementPage.tsx
+++ b/apps/web/src/pages/BodyMeasurementPage.tsx
@@ -113,9 +113,12 @@ export default function BodyMeasurementPage({ onToast }: Props) {
     setImporting(true);
     try {
       const csvText = await file.text();
+      // init.headers を渡すと Hono クライアントが Authorization ヘッダごと
+      // 上書きしてしまう（client.js: ...opt.init が headers の後に展開される）。
+      // import は c.req.text() で読むため Content-Type 指定は不要。body だけ渡す。
       const res = await createClient().api['body-measurements'].import.$post(
         {},
-        { init: { body: csvText, headers: { 'Content-Type': 'text/csv' } } }
+        { init: { body: csvText } }
       );
       if (!res.ok) throw new Error();
       const { created, skipped } = await res.json();

--- a/apps/web/src/pages/FoodMasterPage.tsx
+++ b/apps/web/src/pages/FoodMasterPage.tsx
@@ -74,9 +74,12 @@ export default function FoodMasterPage({ onToast, isAdmin }: Props) {
       if (editing) {
         // PUT は Hono RPC がバリデータなしで json ボディを型推論できないため、
         // param だけ渡し、ボディは init で送る。
+        // init.headers は渡さない: Hono クライアントが {headers, ...opt.init} の順で
+        // 展開するため、init.headers を渡すと Authorization ごと上書きされ 401 になる。
+        // サーバは c.req.json() で読み、Content-Type を見ないため body のみで十分。
         const res = await client.api['food-masters'][':id'].$put(
           { param: { id: editing.id } },
-          { init: { body: JSON.stringify(form), headers: { 'Content-Type': 'application/json' } } }
+          { init: { body: JSON.stringify(form) } }
         );
         if (res.status === 403) {
           onToast({ message: '他のユーザーが作成した食品は編集できません', type: 'error' });

--- a/cloudflare/schema.sql
+++ b/cloudflare/schema.sql
@@ -45,6 +45,34 @@ CREATE TABLE IF NOT EXISTS user_food_stats (
 CREATE INDEX IF NOT EXISTS idx_user_food_stats_usage
   ON user_food_stats(user_id, usage_count DESC, last_used_date DESC);
 
+-- body_measurements: ユーザーごとの体組成計測データ（HealthPlanet由来のCSV全17列）
+-- measured_at（計測のISOタイムスタンプ）を自然キーとし、再インポート時の重複を防ぐ
+CREATE TABLE IF NOT EXISTS body_measurements (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  source_date TEXT,
+  measured_at TEXT NOT NULL,
+  measurement_date_raw TEXT,
+  measurement_time_raw TEXT,
+  measurement_index INTEGER,
+  item_count INTEGER,
+  input_method TEXT,
+  weight_kg REAL,
+  body_fat_percent REAL,
+  muscle_mass_kg REAL,
+  muscle_score REAL,
+  visceral_fat_level REAL,
+  basal_metabolism_kcal REAL,
+  metabolic_age INTEGER,
+  bone_mass_kg REAL,
+  body_water_percent REAL,
+  page_url TEXT,
+  UNIQUE(user_id, measured_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_body_measurements_user_date
+  ON body_measurements(user_id, measured_at);
+
 -- nutrition_goals: ユーザーごとの栄養目標（user_idで分離）
 CREATE TABLE IF NOT EXISTS nutrition_goals (
   user_id TEXT PRIMARY KEY,

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -8,6 +8,7 @@ import nutritionGoals from './routes/nutritionGoals';
 import userData from './routes/userData';
 import csvImport from './routes/csvImport';
 import aiAnalyze from './routes/aiAnalyze';
+import bodyMeasurements from './routes/bodyMeasurements';
 
 const base = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -35,6 +36,7 @@ const app = base
   .route('/api/user-data', userData)
   .route('/api/csv', csvImport)
   .route('/api/ai', aiAnalyze)
+  .route('/api/body-measurements', bodyMeasurements)
   .get('/health', (c) => c.json({ ok: true }));
 
 export default app;

--- a/cloudflare/src/routes/bodyMeasurements.test.ts
+++ b/cloudflare/src/routes/bodyMeasurements.test.ts
@@ -1,0 +1,185 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { issueSessionJwt } from '../middleware/auth';
+
+const TEST_SECRET = 'dev-and-test-secret';
+
+beforeAll(async () => {
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS body_measurements (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      source_date TEXT,
+      measured_at TEXT NOT NULL,
+      measurement_date_raw TEXT,
+      measurement_time_raw TEXT,
+      measurement_index INTEGER,
+      item_count INTEGER,
+      input_method TEXT,
+      weight_kg REAL,
+      body_fat_percent REAL,
+      muscle_mass_kg REAL,
+      muscle_score REAL,
+      visceral_fat_level REAL,
+      basal_metabolism_kcal REAL,
+      metabolic_age INTEGER,
+      bone_mass_kg REAL,
+      body_water_percent REAL,
+      page_url TEXT,
+      UNIQUE(user_id, measured_at)
+    )`
+  ).run();
+});
+
+beforeEach(async () => {
+  await env.DB.prepare('DELETE FROM body_measurements').run();
+});
+
+async function jwtFor(userId: string): Promise<string> {
+  return issueSessionJwt(userId, TEST_SECRET);
+}
+
+async function authedFetch(userId: string, path: string, init: RequestInit = {}) {
+  return SELF.fetch(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${await jwtFor(userId)}`,
+    },
+  });
+}
+
+const CSV_HEADER =
+  'sourceDate,measuredAt,measurementDateRaw,measurementTimeRaw,measurementIndex,itemCount,inputMethod,weightKg,bodyFatPercent,muscleMassKg,muscleScore,visceralFatLevel,basalMetabolismKcal,metabolicAge,boneMassKg,bodyWaterPercent,pageUrl';
+
+function csvRow(measuredAt: string, weightKg: number) {
+  return `2025-01-01,${measuredAt},2025年01月01日,09:04,1,9,対応機器データ,${weightKg},15.2,41,-2,1,1247,18,2.3,54.8,https://example.com`;
+}
+
+describe('認証', () => {
+  it('未認証は 401', async () => {
+    const res = await SELF.fetch('http://localhost/api/body-measurements');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/body-measurements (手動追加)', () => {
+  it('measuredAt が無ければ 400', async () => {
+    const res = await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ weightKg: 50 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('1件追加でき、201 と保存値を返す', async () => {
+    const res = await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ measuredAt: '2025-01-01T00:04:00.000Z', weightKg: 51.2, metabolicAge: 18 }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json<{ id: string; weightKg: number; metabolicAge: number }>();
+    expect(body.weightKg).toBe(51.2);
+    expect(body.metabolicAge).toBe(18);
+    expect(body.id).toBeTruthy();
+  });
+
+  it('同一 measuredAt の重複は 409', async () => {
+    const payload = JSON.stringify({ measuredAt: '2025-01-01T00:04:00.000Z', weightKg: 50 });
+    await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: payload,
+    });
+    const res = await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: payload,
+    });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('GET /api/body-measurements (一覧)', () => {
+  it('自分のデータのみ measured_at 降順で返す', async () => {
+    for (const [u, at, w] of [
+      ['user-a', '2025-01-01T00:00:00.000Z', 50],
+      ['user-a', '2025-01-02T00:00:00.000Z', 51],
+      ['user-b', '2025-01-03T00:00:00.000Z', 60],
+    ] as const) {
+      await authedFetch(u, '/api/body-measurements', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ measuredAt: at, weightKg: w }),
+      });
+    }
+    const res = await authedFetch('user-a', '/api/body-measurements');
+    const { items } = await res.json<{ items: { measuredAt: string; weightKg: number }[] }>();
+    expect(items).toHaveLength(2);
+    expect(items[0].measuredAt).toBe('2025-01-02T00:00:00.000Z');
+    expect(items[1].measuredAt).toBe('2025-01-01T00:00:00.000Z');
+  });
+});
+
+describe('DELETE /api/body-measurements/:id', () => {
+  it('自分のデータを削除できる', async () => {
+    const created = await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ measuredAt: '2025-01-01T00:00:00.000Z', weightKg: 50 }),
+    });
+    const { id } = await created.json<{ id: string }>();
+    const res = await authedFetch('user-a', `/api/body-measurements/${id}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+
+    const list = await authedFetch('user-a', '/api/body-measurements');
+    const { items } = await list.json<{ items: unknown[] }>();
+    expect(items).toHaveLength(0);
+  });
+
+  it('他ユーザーのデータは削除できず 404', async () => {
+    const created = await authedFetch('user-a', '/api/body-measurements', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ measuredAt: '2025-01-01T00:00:00.000Z', weightKg: 50 }),
+    });
+    const { id } = await created.json<{ id: string }>();
+    const res = await authedFetch('user-b', `/api/body-measurements/${id}`, { method: 'DELETE' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/body-measurements/import (CSV一括)', () => {
+  it('全17列をパースして登録する', async () => {
+    const csv = [CSV_HEADER, csvRow('2025-01-01T00:04:00.000Z', 51), csvRow('2025-01-01T11:34:00.000Z', 51.6)].join('\n');
+    const res = await authedFetch('user-a', '/api/body-measurements/import', {
+      method: 'POST', headers: { 'Content-Type': 'text/csv' }, body: csv,
+    });
+    expect(res.status).toBe(200);
+    const { created } = await res.json<{ created: number; skipped: number }>();
+    expect(created).toBe(2);
+
+    const list = await authedFetch('user-a', '/api/body-measurements');
+    const { items } = await list.json<{ items: { weightKg: number; muscleScore: number; metabolicAge: number; inputMethod: string }[] }>();
+    expect(items).toHaveLength(2);
+    expect(items[0].muscleScore).toBe(-2);
+    expect(items[0].metabolicAge).toBe(18);
+    expect(items[0].inputMethod).toBe('対応機器データ');
+  });
+
+  it('再インポート時に既存の measured_at はスキップする', async () => {
+    const csv = [CSV_HEADER, csvRow('2025-01-01T00:04:00.000Z', 51)].join('\n');
+    await authedFetch('user-a', '/api/body-measurements/import', {
+      method: 'POST', headers: { 'Content-Type': 'text/csv' }, body: csv,
+    });
+    const res = await authedFetch('user-a', '/api/body-measurements/import', {
+      method: 'POST', headers: { 'Content-Type': 'text/csv' }, body: csv,
+    });
+    const { created, skipped } = await res.json<{ created: number; skipped: number }>();
+    expect(created).toBe(0);
+    expect(skipped).toBe(1);
+  });
+
+  it('データ行が無ければ 400', async () => {
+    const res = await authedFetch('user-a', '/api/body-measurements/import', {
+      method: 'POST', headers: { 'Content-Type': 'text/csv' }, body: CSV_HEADER,
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/cloudflare/src/routes/bodyMeasurements.ts
+++ b/cloudflare/src/routes/bodyMeasurements.ts
@@ -1,0 +1,175 @@
+import { Hono } from 'hono';
+import type { Bindings, Variables, BodyMeasurementRow } from '../types';
+import { bodyMeasurementToResponse } from '../types';
+import { authMiddleware } from '../middleware/auth';
+
+const BATCH_SIZE = 100;
+const DEFAULT_LIMIT = 1000;
+
+// CSVの1行をパースする（log_items のCSVインポートと同じ簡易パーサ）
+function parseCSVLine(line: string): string[] {
+  const columns: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (const char of line) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      columns.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  columns.push(current.trim());
+  return columns;
+}
+
+// CSVのcamelCaseヘッダ → DBカラム名（DBへのbind順序もこの定義順に従う）
+const FIELD_DEFS: { csv: string; col: string; kind: 'text' | 'real' | 'int' }[] = [
+  { csv: 'sourceDate',           col: 'source_date',           kind: 'text' },
+  { csv: 'measuredAt',           col: 'measured_at',           kind: 'text' },
+  { csv: 'measurementDateRaw',   col: 'measurement_date_raw',  kind: 'text' },
+  { csv: 'measurementTimeRaw',   col: 'measurement_time_raw',  kind: 'text' },
+  { csv: 'measurementIndex',     col: 'measurement_index',     kind: 'int' },
+  { csv: 'itemCount',            col: 'item_count',            kind: 'int' },
+  { csv: 'inputMethod',          col: 'input_method',          kind: 'text' },
+  { csv: 'weightKg',             col: 'weight_kg',             kind: 'real' },
+  { csv: 'bodyFatPercent',       col: 'body_fat_percent',      kind: 'real' },
+  { csv: 'muscleMassKg',         col: 'muscle_mass_kg',        kind: 'real' },
+  { csv: 'muscleScore',          col: 'muscle_score',          kind: 'real' },
+  { csv: 'visceralFatLevel',     col: 'visceral_fat_level',    kind: 'real' },
+  { csv: 'basalMetabolismKcal',  col: 'basal_metabolism_kcal', kind: 'real' },
+  { csv: 'metabolicAge',         col: 'metabolic_age',         kind: 'int' },
+  { csv: 'boneMassKg',           col: 'bone_mass_kg',          kind: 'real' },
+  { csv: 'bodyWaterPercent',     col: 'body_water_percent',    kind: 'real' },
+  { csv: 'pageUrl',              col: 'page_url',              kind: 'text' },
+];
+
+const COLUMNS = FIELD_DEFS.map((f) => f.col);
+
+// 文字列値を kind に応じて DB へbindできる値（number/string/null）に変換する
+function coerce(raw: string | undefined, kind: 'text' | 'real' | 'int'): number | string | null {
+  const v = raw?.trim();
+  if (v === undefined || v === '') return null;
+  if (kind === 'text') return v;
+  const n = kind === 'int' ? parseInt(v, 10) : parseFloat(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+// camelCaseフィールドを持つレコードを COLUMNS 順の bind 値配列へ変換する
+function recordToValues(rec: Record<string, unknown>): (number | string | null)[] {
+  return FIELD_DEFS.map((f) => coerce(rec[f.csv] != null ? String(rec[f.csv]) : undefined, f.kind));
+}
+
+function insertStmt(db: D1Database, id: string, userId: string, values: (number | string | null)[]) {
+  const placeholders = COLUMNS.map(() => '?').join(', ');
+  return db
+    .prepare(
+      `INSERT OR IGNORE INTO body_measurements (id, user_id, ${COLUMNS.join(', ')})
+       VALUES (?, ?, ${placeholders})`
+    )
+    .bind(id, userId, ...values);
+}
+
+const bodyMeasurements = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .use('*', authMiddleware)
+  // GET / : ユーザーの計測データを measured_at 降順で返す
+  .get('/', async (c) => {
+    const userId = c.get('userId');
+    const limitParam = parseInt(c.req.query('limit') ?? '', 10);
+    const limit = Number.isNaN(limitParam) ? DEFAULT_LIMIT : Math.min(Math.max(limitParam, 1), 5000);
+
+    const { results } = await c.env.DB.prepare(
+      `SELECT * FROM body_measurements WHERE user_id = ? ORDER BY measured_at DESC LIMIT ?`
+    )
+      .bind(userId, limit)
+      .all<BodyMeasurementRow>();
+
+    return c.json({ items: results.map(bodyMeasurementToResponse) });
+  })
+  // POST / : 手動で1件追加。measuredAt 必須。重複（同一measured_at）は 409
+  .post('/', async (c) => {
+    const userId = c.get('userId');
+    const body = await c.req.json<Record<string, unknown>>();
+
+    const measuredAt = typeof body.measuredAt === 'string' ? body.measuredAt.trim() : '';
+    if (!measuredAt) return c.json({ error: 'measuredAt is required' }, 400);
+
+    const id = crypto.randomUUID();
+    const values = recordToValues(body);
+    const res = await insertStmt(c.env.DB, id, userId, values).run();
+    if (res.meta.changes === 0) {
+      return c.json({ error: 'A measurement at this time already exists' }, 409);
+    }
+
+    const row = await c.env.DB.prepare(
+      `SELECT * FROM body_measurements WHERE id = ?`
+    )
+      .bind(id)
+      .first<BodyMeasurementRow>();
+    return c.json(bodyMeasurementToResponse(row!), 201);
+  })
+  // DELETE /:id : 自分の計測データを1件削除
+  .delete('/:id', async (c) => {
+    const userId = c.get('userId');
+    const id = c.req.param('id');
+    const res = await c.env.DB.prepare(
+      `DELETE FROM body_measurements WHERE id = ? AND user_id = ?`
+    )
+      .bind(id, userId)
+      .run();
+    if (res.meta.changes === 0) return c.json({ error: 'Not found' }, 404);
+    return c.json({ deleted: true });
+  })
+  // POST /import : CSV（全17列）を一括登録。重複は INSERT OR IGNORE でスキップ
+  .post('/import', async (c) => {
+    const userId = c.get('userId');
+    const csvText = await c.req.text();
+
+    const lines = csvText.split(/\r?\n/).filter((l) => l.trim());
+    if (lines.length < 2) return c.json({ error: 'CSV has no data rows' }, 400);
+
+    const headers = parseCSVLine(lines[0]);
+    const measuredAtIdx = headers.indexOf('measuredAt');
+    if (measuredAtIdx < 0) {
+      return c.json({ error: 'CSV must contain a measuredAt column' }, 400);
+    }
+    // CSVヘッダ名 → 列インデックス
+    const idxByCsv = new Map(headers.map((h, i) => [h, i]));
+
+    type Pending = { id: string; values: (number | string | null)[] };
+    const pending: Pending[] = [];
+    let skipped = 0;
+    // 同一CSV内での measured_at 重複も排除する
+    const seen = new Set<string>();
+
+    for (const line of lines.slice(1)) {
+      const cols = parseCSVLine(line);
+      const measuredAt = cols[measuredAtIdx]?.trim();
+      if (!measuredAt || seen.has(measuredAt)) {
+        skipped++;
+        continue;
+      }
+      seen.add(measuredAt);
+
+      const values = FIELD_DEFS.map((f) => {
+        const i = idxByCsv.get(f.csv);
+        return coerce(i === undefined ? undefined : cols[i], f.kind);
+      });
+      pending.push({ id: crypto.randomUUID(), values });
+    }
+
+    let created = 0;
+    for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+      const chunk = pending.slice(i, i + BATCH_SIZE);
+      const results = await c.env.DB.batch(
+        chunk.map((p) => insertStmt(c.env.DB, p.id, userId, p.values))
+      );
+      created += results.filter((r) => r.meta.changes > 0).length;
+    }
+
+    return c.json({ created, skipped: skipped + (pending.length - created) });
+  });
+
+export default bodyMeasurements;

--- a/cloudflare/src/types.ts
+++ b/cloudflare/src/types.ts
@@ -52,6 +52,51 @@ export type NutritionGoalsRow = {
   target_fiber: number;
 };
 
+export type BodyMeasurementRow = {
+  id: string;
+  user_id: string;
+  source_date: string | null;
+  measured_at: string;
+  measurement_date_raw: string | null;
+  measurement_time_raw: string | null;
+  measurement_index: number | null;
+  item_count: number | null;
+  input_method: string | null;
+  weight_kg: number | null;
+  body_fat_percent: number | null;
+  muscle_mass_kg: number | null;
+  muscle_score: number | null;
+  visceral_fat_level: number | null;
+  basal_metabolism_kcal: number | null;
+  metabolic_age: number | null;
+  bone_mass_kg: number | null;
+  body_water_percent: number | null;
+  page_url: string | null;
+};
+
+export function bodyMeasurementToResponse(row: BodyMeasurementRow) {
+  return {
+    id: row.id,
+    sourceDate: row.source_date,
+    measuredAt: row.measured_at,
+    measurementDateRaw: row.measurement_date_raw,
+    measurementTimeRaw: row.measurement_time_raw,
+    measurementIndex: row.measurement_index,
+    itemCount: row.item_count,
+    inputMethod: row.input_method,
+    weightKg: row.weight_kg,
+    bodyFatPercent: row.body_fat_percent,
+    muscleMassKg: row.muscle_mass_kg,
+    muscleScore: row.muscle_score,
+    visceralFatLevel: row.visceral_fat_level,
+    basalMetabolismKcal: row.basal_metabolism_kcal,
+    metabolicAge: row.metabolic_age,
+    boneMassKg: row.bone_mass_kg,
+    bodyWaterPercent: row.body_water_percent,
+    pageUrl: row.page_url,
+  };
+}
+
 export function foodMasterToResponse(row: FoodMasterRow) {
   return {
     id: row.id,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,34 @@
+# 体組成計測データ（body_measurements）機能
+
+HealthPlanet 由来の体組成計測データ（体重・体脂肪率・筋肉量など17列）を
+ユーザーに紐づけて保存し、web画面から CSV一括 + 手動1件追加で登録できるようにする。
+
+## 方針（ユーザー確認済み）
+- 登録方法: CSV一括アップロード + 手動1件追加フォーム
+- 保存カラム: CSV全17カラム
+- 重複防止: UNIQUE(user_id, measured_at)
+
+## タスク
+- [x] schema.sql に body_measurements テーブル追加
+- [x] types.ts に BodyMeasurementRow + bodyMeasurementToResponse
+- [x] routes/bodyMeasurements.ts (GET / POST / DELETE /:id / POST /import)
+- [x] index.ts にルート登録
+- [x] routes/bodyMeasurements.test.ts（10件パス）
+- [x] hooks/useBodyMeasurements.ts (SWR)
+- [x] pages/BodyMeasurementPage.tsx (一覧 + 手動追加 + CSVアップロード)
+- [x] Sidebar.tsx / App.tsx に BODY タブ追加
+- [x] npm test（52件パス）/ bun run build（成功）で検証
+- [x] ローカルD1へスキーマ適用済み（npx wrangler d1 execute bitelog --local --file=schema.sql）
+
+## レビュー
+- `body_measurements` テーブルを新設。CSV全17列 + id + user_id を保存し、
+  UNIQUE(user_id, measured_at) で再インポート/手動追加の重複を防止。
+- API: GET一覧（measured_at降順）/ POST手動1件 / DELETE 1件 / POST import（CSV一括・
+  バッチ100件・INSERT OR IGNORE）。すべて authMiddleware でユーザー分離。
+- Web: BODY タブを追加。一覧テーブル + 手動追加モーダル + CSVアップロード。
+- 既存パターン（Hono RPC, SWR, FoodMasterPage のモーダル/テーブル）に踏襲。
+
+## 残作業（デプロイ時・ユーザー操作）
+- 本番D1へのスキーマ適用: cd cloudflare && npx wrangler d1 execute bitelog --remote --file=schema.sql
+- Worker デプロイ: cd cloudflare && npm run deploy
+- Web Pages デプロイ: bun run build → npx wrangler pages deploy ../apps/web/dist --project-name bitelog-admin --branch main


### PR DESCRIPTION
## Why
HealthPlanet 由来の体組成計測データ（体重・体脂肪率・筋肉量など）を、栄養記録と並べてユーザーごとに管理したい。数千行ある過去データの取り込みと、日々の手動追加の両方に対応する。

## What
- **DB**: `body_measurements` テーブルを新設（CSV全17列 + `id` + `user_id`）。`UNIQUE(user_id, measured_at)` で再インポート・手動追加の重複を防止
- **API** (`/api/body-measurements`, 全て `authMiddleware` でユーザー分離)
  - `GET /` 一覧（measured_at 降順）
  - `POST /` 手動1件追加（重複は409）
  - `DELETE /:id` 削除（他人のデータは404）
  - `POST /import` CSV一括（バッチ100件・`INSERT OR IGNORE` で重複スキップ）
- **Web**: サイドバーに **BODY** タブを追加。一覧テーブル + 手動追加モーダル + CSVアップロード。既存の Hono RPC / SWR / FoodMasterPage のパターンを踏襲

## Test
- Worker テスト 52件パス（新規 `bodyMeasurements.test.ts` 10件含む）
- web build + 型チェック成功

## Deploy
本PRの内容は既に本番へ反映済み:
- 本番D1にスキーマ適用済み（`body_measurements` 作成、num_tables: 6）
- Worker デプロイ済み（version 4bb3b539）
- Web Pages デプロイ済み（bitelog-admin / branch main）

🤖 Generated with [Claude Code](https://claude.com/claude-code)