### PR TITLE
feat: 統計ページに体組成×栄養素の相関ダッシュボードを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ apps/docs/dist/
 # Debug / test artifacts
 .playwright-mcp/
 screenshot-*.png
+
+# Personal body-composition data (HealthPlanet export) — never commit
+measurements.csv

--- a/apps/web/src/hooks/useDailyStats.ts
+++ b/apps/web/src/hooks/useDailyStats.ts
@@ -1,0 +1,23 @@
+import useSWR from 'swr';
+import { createClient } from '@/lib/api';
+import type { DailyStat } from '@/lib/correlation';
+
+async function fetchDailyStats([, from, to]: [string, string, string]): Promise<DailyStat[]> {
+  const res = await createClient().api.statistics.daily.$get({ query: { from, to } });
+  if (!res.ok) throw new Error('statistics/daily');
+  const data = await res.json();
+  return data.items as DailyStat[];
+}
+
+/**
+ * 表示レンジ [from, to] の日次サマリ（栄養合計＋体組成平均をサーバー側でマージ済み）を取得。
+ * useSummary と同様、レンジを SWR キーにして ◀▶ のレンジ移動だけ再取得し、
+ * bucket/metric 切替（同一レンジ）では再取得しない。
+ */
+export function useDailyStats(from: string, to: string, onError: () => void) {
+  return useSWR<DailyStat[]>(['stats-daily', from, to], fetchDailyStats, {
+    keepPreviousData: true,
+    revalidateOnFocus: false,
+    onError,
+  });
+}

--- a/apps/web/src/lib/correlation.ts
+++ b/apps/web/src/lib/correlation.ts
@@ -1,0 +1,171 @@
+// 統計ページの「栄養素×体組成」相関ダッシュボード用ロジック。
+// API /statistics/daily（サーバー側で日次集計・マージ済み）の行を、
+// 期間/バケット/集計に応じて二軸グラフ用の系列へ整形する純粋関数群。
+//
+// 栄養素は lib/statistics.ts の集計と同じ思想（合計 or 暦日数で割った日平均）。
+// 体組成は合計に意味が無いため平均のみ。記録の無い日は null（折れ線を欠落させる）。
+
+import type { Bucket } from './statistics';
+import { parseDate, formatDate, startOfWeek, startOfMonth } from './statistics';
+
+/** API /statistics/daily が返す日次1行（栄養合計＋体組成平均をマージ済み）。 */
+export interface DailyStat {
+  date: string; // "yyyy-MM-dd"
+  calories: number;
+  protein: number;
+  fat: number;
+  netCarbs: number;
+  dietaryFiber: number;
+  weightKg: number | null;
+  bodyFatPercent: number | null;
+  muscleMassKg: number | null;
+  muscleScore: number | null;
+  visceralFatLevel: number | null;
+  basalMetabolismKcal: number | null;
+  metabolicAge: number | null;
+  boneMassKg: number | null;
+  bodyWaterPercent: number | null;
+}
+
+/** 折れ線の対象になる体組成指標（DailyStat の number|null フィールド）。 */
+export type BodyMetricKey =
+  | 'weightKg' | 'bodyFatPercent' | 'muscleMassKg' | 'muscleScore'
+  | 'visceralFatLevel' | 'basalMetabolismKcal' | 'metabolicAge'
+  | 'boneMassKg' | 'bodyWaterPercent';
+
+export interface BodyMetricConfig {
+  key: BodyMetricKey;
+  label: string;
+  unit: string;
+  color: string;
+}
+
+// 折れ線（体組成）の色は、栄養素の棒グラフ4色（calories=#ffff00 / protein=#00ff41 /
+// fat=#ff00ff / carbs=#00e5ff）と必ず別系統にする。体組成は同時に1本しか描かないため、
+// 選択中の栄養素色とだけ被らなければよい。既定の WEIGHT は黄色のカロリー棒と最も
+// コントラストが出る青系にしている。
+export const BODY_METRICS: BodyMetricConfig[] = [
+  { key: 'weightKg',            label: 'WEIGHT',       unit: 'kg',   color: '#38bdf8' },
+  { key: 'bodyFatPercent',      label: 'BODY FAT',     unit: '%',    color: '#ff3366' },
+  { key: 'muscleMassKg',        label: 'MUSCLE',       unit: 'kg',   color: '#a855f7' },
+  { key: 'muscleScore',         label: 'MUSCLE SCORE', unit: '',     color: '#fb923c' },
+  { key: 'visceralFatLevel',    label: 'VISCERAL FAT', unit: '',     color: '#f43f5e' },
+  { key: 'basalMetabolismKcal', label: 'BMR',          unit: 'kcal', color: '#c084fc' },
+  { key: 'metabolicAge',        label: 'META AGE',     unit: 'yr',   color: '#2dd4bf' },
+  { key: 'boneMassKg',          label: 'BONE MASS',    unit: 'kg',   color: '#94a3b8' },
+  { key: 'bodyWaterPercent',    label: 'BODY WATER',   unit: '%',    color: '#60a5fa' },
+];
+
+/** 表示する栄養素軸（StatisticsPage の Metric と揃える）。 */
+export type NutrientKey = 'calories' | 'protein' | 'fat' | 'carbs';
+
+export function nutrientValue(d: DailyStat, k: NutrientKey): number {
+  switch (k) {
+    case 'calories': return d.calories;
+    case 'protein':  return d.protein;
+    case 'fat':      return d.fat;
+    case 'carbs':    return d.netCarbs + d.dietaryFiber; // iOS の carbs と同じ
+  }
+}
+
+/** 期間内に体組成データが1つでもあるか（無ければセクションを出さない判定に使う）。 */
+export function hasBodyData(items: DailyStat[]): boolean {
+  return items.some((d) => BODY_METRICS.some((m) => d[m.key] != null));
+}
+
+function nextDay(s: string): string {
+  const d = parseDate(s);
+  d.setDate(d.getDate() + 1);
+  return formatDate(d);
+}
+
+function daysInMonth(monthStart: string): number {
+  const d = parseDate(monthStart);
+  return new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+}
+
+export interface CorrelationPoint {
+  date: string;
+  nutrient: number;
+  body: number | null;
+}
+
+/**
+ * 二軸グラフ用の系列を生成。
+ * - day: [from, to] を1日刻みで埋める（栄養＝値 or 0、体組成＝値 or null）。
+ * - week/month: バケット集計。栄養は average なら暦日数で割った日平均、それ以外は合計。
+ *   体組成はバケット内の非 null 値の平均（無ければ null）。
+ */
+export function correlationSeries(
+  items: DailyStat[],
+  from: string,
+  to: string,
+  bucket: Bucket,
+  average: boolean,
+  nutrient: NutrientKey,
+  body: BodyMetricKey,
+): CorrelationPoint[] {
+  const byDate = new Map(items.map((d) => [d.date, d]));
+
+  // まず [from, to] の連続日次系列に展開。
+  const daily: CorrelationPoint[] = [];
+  let cur = from;
+  while (cur <= to) {
+    const d = byDate.get(cur);
+    daily.push({
+      date: cur,
+      nutrient: d ? nutrientValue(d, nutrient) : 0,
+      body: d ? d[body] : null,
+    });
+    cur = nextDay(cur);
+  }
+
+  if (bucket === 'day') return daily;
+
+  // 週/月バケットへ集計。
+  const groups = new Map<string, { nSum: number; bSum: number; bCount: number }>();
+  for (const p of daily) {
+    const date = parseDate(p.date);
+    const start = bucket === 'week' ? startOfWeek(date) : startOfMonth(date);
+    const key = formatDate(start);
+    const g = groups.get(key) ?? { nSum: 0, bSum: 0, bCount: 0 };
+    g.nSum += p.nutrient;
+    if (p.body != null) {
+      g.bSum += p.body;
+      g.bCount += 1;
+    }
+    groups.set(key, g);
+  }
+
+  return [...groups.entries()]
+    .map(([key, g]) => {
+      const div = bucket === 'week' ? 7 : daysInMonth(key);
+      return {
+        date: key,
+        nutrient: average ? g.nSum / Math.max(div, 1) : g.nSum,
+        body: g.bCount > 0 ? g.bSum / g.bCount : null,
+      };
+    })
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** 期間内の体組成指標について、最新値と期間始端比の差分を返す（サマリ表示用）。 */
+export interface BodyDelta {
+  key: BodyMetricKey;
+  latest: number | null;
+  delta: number | null; // latest - earliest（同一日のみだと null）
+}
+
+export function bodyDeltas(items: DailyStat[]): BodyDelta[] {
+  return BODY_METRICS.map((m) => {
+    const present = items.filter((d) => d[m.key] != null) as (DailyStat & Record<BodyMetricKey, number>)[];
+    if (present.length === 0) return { key: m.key, latest: null, delta: null };
+    const earliest = present[0][m.key];
+    const latest = present[present.length - 1][m.key];
+    return {
+      key: m.key,
+      latest,
+      delta: present.length > 1 ? latest - earliest : null,
+    };
+  });
+}

--- a/apps/web/src/pages/StatisticsPage.tsx
+++ b/apps/web/src/pages/StatisticsPage.tsx
@@ -1,18 +1,27 @@
 import { useState, useMemo, useCallback } from 'react';
 import { motion } from 'motion/react';
 import {
-  LineChart, Line, BarChart, Bar,
+  Line, Bar, ComposedChart,
   XAxis, YAxis, Tooltip, ResponsiveContainer, ReferenceLine,
 } from 'recharts';
 import type { ToastMessage } from '@/components/Toast';
 import { useSummary } from '@/hooks/useStatistics';
+import { useDailyStats } from '@/hooks/useDailyStats';
+import { useBodyMeasurements } from '@/hooks/useBodyMeasurements';
 import { useNutritionGoals, targetCalories } from '@/hooks/useNutritionGoals';
 import {
-  dailyTotals, fillDays, bucketed, periodTotal, dailyAverage,
+  dailyTotals, fillDays, periodTotal, dailyAverage,
   goalAchievedDays, pfcBalance, mealTypeTotals, carbs,
   formatDate,
-  type NutritionValues, type Bucket,
+  type Bucket,
 } from '@/lib/statistics';
+import {
+  BODY_METRICS, correlationSeries, bodyDeltas,
+  type BodyMetricKey,
+} from '@/lib/correlation';
+
+// 体組成の折れ線。'off' で非表示。
+type BodyLine = BodyMetricKey | 'off';
 
 type Period = 'week' | 'month' | 'year';
 type Metric = 'calories' | 'protein' | 'fat' | 'carbs';
@@ -48,15 +57,6 @@ const BUCKETS_FOR: Record<Period, Bucket[]> = {
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const DAYS   = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-function metricValue(v: NutritionValues, m: Metric): number {
-  switch (m) {
-    case 'calories': return v.calories;
-    case 'protein':  return v.protein;
-    case 'fat':      return v.fat;
-    case 'carbs':    return carbs(v);
-  }
-}
 
 /** 今日を基準に、offset ページ分だけ過去にずらした表示レンジ [from, to]。 */
 function rangeFor(period: Period, offset: number): { from: string; to: string } {
@@ -172,6 +172,7 @@ export default function StatisticsPage({ onToast }: Props) {
   const [bucket, setBucket]           = useState<Bucket>('day');
   const [aggregation, setAggregation] = useState<Aggregation>('total');
   const [offset, setOffset]           = useState(0);
+  const [bodyMetric, setBodyMetric]   = useState<BodyLine>('weightKg');
 
   const { from, to } = useMemo(() => rangeFor(period, offset), [period, offset]);
 
@@ -180,6 +181,10 @@ export default function StatisticsPage({ onToast }: Props) {
     [onToast]
   );
   const { data: items = [], isLoading } = useSummary(from, to, onError);
+  const { data: daily = [] } = useDailyStats(from, to, onError);
+  // ユーザーが体組成データを保有しているか（measured_at 降順・最新が先頭）。
+  // 選択期間外でもセクションを出して「期間外」を案内するために使う。
+  const { data: allBody = [] } = useBodyMeasurements();
   const { data: rawGoals } = useNutritionGoals();
   const goals = {
     calories: rawGoals ? targetCalories(rawGoals) : 0,
@@ -206,13 +211,6 @@ export default function StatisticsPage({ onToast }: Props) {
     [items, from, to]
   );
 
-  const chartData = useMemo(() => {
-    const series = bucket === 'day'
-      ? filledDaily
-      : bucketed(filledDaily, bucket, aggregation === 'average');
-    return series.map((d) => ({ date: d.date, value: metricValue(d.values, metric) }));
-  }, [filledDaily, bucket, aggregation, metric]);
-
   const avg     = useMemo(() => dailyAverage(items, days), [items, days]);
   const total   = useMemo(() => periodTotal(items), [items]);
   const balance = useMemo(() => pfcBalance(items), [items]);
@@ -227,6 +225,18 @@ export default function StatisticsPage({ onToast }: Props) {
 
   const metricConf = METRIC_CONFIG[metric];
   const xFormatter = makeXFormatter(period, bucket);
+
+  // ─── Body composition (correlation) ──────────────────────
+  const hasAnyBody = allBody.length > 0;                       // 全期間で体組成データを持っているか
+  const bodyLineActive = hasAnyBody && bodyMetric !== 'off';   // 折れ線を描くか
+  const effectiveBodyKey: BodyMetricKey = bodyMetric === 'off' ? 'weightKg' : bodyMetric;
+  const bodyConf = BODY_METRICS.find((m) => m.key === effectiveBodyKey)!;
+  // 栄養素（棒/折れ線）と体組成（折れ線）を同一の日次系列にまとめてグラフ描画する。
+  const corrData = useMemo(
+    () => correlationSeries(daily, from, to, bucket, aggregation === 'average', metric, effectiveBodyKey),
+    [daily, from, to, bucket, aggregation, metric, effectiveBodyKey]
+  );
+  const deltas = useMemo(() => bodyDeltas(daily), [daily]);
 
   // 合計バケットでは日次目標と比較できないため、目標線は日次か平均のときだけ。
   const showGoalLine = metric === 'calories' && goals.calories > 0
@@ -292,7 +302,7 @@ export default function StatisticsPage({ onToast }: Props) {
           </div>
 
           {/* Bucket / aggregation controls */}
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center justify-between mb-3">
             {availableBuckets.length > 1 ? (
               <Segmented
                 options={availableBuckets.map((b) => ({ key: b, label: b }))}
@@ -309,73 +319,92 @@ export default function StatisticsPage({ onToast }: Props) {
             )}
           </div>
 
+          {/* Body line toggle（体組成データを持つ場合のみ。OFF で折れ線を非表示） */}
+          {hasAnyBody && (
+            <div className="flex items-center gap-2 mb-4 overflow-x-auto">
+              <span className="text-xs text-muted-foreground tracking-widest flex-shrink-0">BODY</span>
+              <Segmented
+                options={[
+                  { key: 'off' as BodyLine, label: 'off' },
+                  ...BODY_METRICS.map((m) => ({ key: m.key as BodyLine, label: m.label })),
+                ]}
+                value={bodyMetric}
+                onChange={setBodyMetric}
+                colorFor={(k) => (k === 'off' ? '#6060a0' : BODY_METRICS.find((m) => m.key === k)!.color)}
+              />
+            </div>
+          )}
+
           {isLoading ? (
             <div className="h-44 flex items-center justify-center text-muted-foreground tracking-widest text-xs">LOADING...</div>
           ) : (
-            <ResponsiveContainer width="100%" height={176}>
-              {bucket === 'day' ? (
-                <LineChart data={chartData} margin={{ top: 5, right: 4, bottom: 5, left: 4 }}>
-                  <XAxis
-                    dataKey="date"
-                    tickFormatter={xFormatter}
-                    tick={{ fill: '#6060a0', fontSize: 9, fontFamily: 'JetBrains Mono, monospace' }}
-                    axisLine={false} tickLine={false}
-                    interval={chartData.length <= 8 ? 0 : 'preserveStartEnd'}
+            <ResponsiveContainer width="100%" height={188}>
+              <ComposedChart data={corrData} margin={{ top: 5, right: 4, bottom: 5, left: 4 }}>
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={xFormatter}
+                  tick={{ fill: '#6060a0', fontSize: 9, fontFamily: 'JetBrains Mono, monospace' }}
+                  axisLine={false} tickLine={false}
+                  interval={bucket === 'day' && corrData.length > 8 ? 'preserveStartEnd' : 0}
+                />
+                <YAxis yAxisId="nutrient" hide domain={[0, 'auto']} />
+                <YAxis yAxisId="body" orientation="right" hide domain={['auto', 'auto']} />
+                <Tooltip
+                  {...chartTooltipStyle}
+                  formatter={(v, name) =>
+                    name === metricConf.label
+                      ? [`${Math.round(Number(v) * 10) / 10} ${metricConf.unit}`, metricConf.label]
+                      : [`${Math.round(Number(v) * 10) / 10} ${bodyConf.unit}`, bodyConf.label]
+                  }
+                  labelFormatter={(label) => xFormatter(String(label))}
+                />
+                {showGoalLine && (
+                  <ReferenceLine
+                    yAxisId="nutrient"
+                    y={goals.calories}
+                    stroke="#ffffff25"
+                    strokeDasharray="4 4"
+                    label={{ value: `${goals.calories} goal`, fill: '#6060a0', fontSize: 8, fontFamily: 'JetBrains Mono, monospace', position: 'insideTopRight' }}
                   />
-                  <YAxis hide domain={[0, 'auto']} />
-                  <Tooltip
-                    {...chartTooltipStyle}
-                    itemStyle={{ color: metricConf.color }}
-                    formatter={(v) => [`${Math.round(Number(v) * 10) / 10} ${metricConf.unit}`, metricConf.label]}
-                    labelFormatter={(label) => xFormatter(String(label))}
-                  />
-                  {showGoalLine && (
-                    <ReferenceLine
-                      y={goals.calories}
-                      stroke="#ffffff25"
-                      strokeDasharray="4 4"
-                      label={{ value: `${goals.calories} goal`, fill: '#6060a0', fontSize: 8, fontFamily: 'JetBrains Mono, monospace', position: 'insideTopRight' }}
-                    />
-                  )}
+                )}
+                {bucket === 'day' ? (
                   <Line
+                    yAxisId="nutrient"
                     type="monotone"
-                    dataKey="value"
+                    dataKey="nutrient"
+                    name={metricConf.label}
                     stroke={metricConf.color}
                     strokeWidth={1.5}
-                    dot={chartData.length <= 14 ? { r: 3, fill: metricConf.color, stroke: 'none' } : false}
+                    dot={corrData.length <= 14 ? { r: 3, fill: metricConf.color, stroke: 'none' } : false}
                     activeDot={{ r: 4, fill: metricConf.color, stroke: 'none' }}
                     style={{ filter: `drop-shadow(0 0 4px ${metricConf.color}80)` }}
                   />
-                </LineChart>
-              ) : (
-                <BarChart data={chartData} margin={{ top: 5, right: 4, bottom: 5, left: 4 }}>
-                  <XAxis
-                    dataKey="date"
-                    tickFormatter={xFormatter}
-                    tick={{ fill: '#6060a0', fontSize: 9, fontFamily: 'JetBrains Mono, monospace' }}
-                    axisLine={false} tickLine={false}
-                    interval="preserveStartEnd"
-                  />
-                  <YAxis hide domain={[0, 'auto']} />
-                  <Tooltip
-                    {...chartTooltipStyle}
-                    itemStyle={{ color: metricConf.color }}
-                    formatter={(v) => [`${Math.round(Number(v) * 10) / 10} ${metricConf.unit}`, metricConf.label]}
-                    labelFormatter={(label) => xFormatter(String(label))}
-                  />
-                  {showGoalLine && (
-                    <ReferenceLine
-                      y={goals.calories}
-                      stroke="#ffffff25"
-                      strokeDasharray="4 4"
-                      label={{ value: `${goals.calories} goal`, fill: '#6060a0', fontSize: 8, fontFamily: 'JetBrains Mono, monospace', position: 'insideTopRight' }}
-                    />
-                  )}
-                  <Bar dataKey="value" fill={metricConf.color} fillOpacity={0.75} radius={[1, 1, 0, 0]}
+                ) : (
+                  <Bar
+                    yAxisId="nutrient"
+                    dataKey="nutrient"
+                    name={metricConf.label}
+                    fill={metricConf.color}
+                    fillOpacity={bodyLineActive ? 0.4 : 0.75}
+                    radius={[1, 1, 0, 0]}
                     style={{ filter: `drop-shadow(0 0 3px ${metricConf.color}60)` }}
                   />
-                </BarChart>
-              )}
+                )}
+                {bodyLineActive && (
+                  <Line
+                    yAxisId="body"
+                    type="monotone"
+                    dataKey="body"
+                    name={bodyConf.label}
+                    stroke={bodyConf.color}
+                    strokeWidth={2}
+                    connectNulls={false}
+                    dot={corrData.length <= 31 ? { r: 2.5, fill: bodyConf.color, stroke: 'none' } : false}
+                    activeDot={{ r: 4, fill: bodyConf.color, stroke: 'none' }}
+                    style={{ filter: `drop-shadow(0 0 4px ${bodyConf.color}80)` }}
+                  />
+                )}
+              </ComposedChart>
             </ResponsiveContainer>
           )}
         </motion.div>
@@ -482,6 +511,41 @@ export default function StatisticsPage({ onToast }: Props) {
           </motion.div>
 
         </div>
+
+        {/* Latest body composition + 期間始端比の差分（選択期間に体組成データがある場合のみ） */}
+        {deltas.some((d) => d.latest != null) && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.08 }}
+            className="bg-bg-card border border-border-dim p-4"
+          >
+            <div className="text-xs text-muted-foreground tracking-widest mb-3">BODY COMPOSITION</div>
+            <div className="grid grid-cols-3 gap-x-4 gap-y-3">
+              {BODY_METRICS.map((m) => {
+                const d = deltas.find((x) => x.key === m.key)!;
+                if (d.latest == null) return null;
+                const up = d.delta != null && d.delta > 0;
+                const down = d.delta != null && d.delta < 0;
+                return (
+                  <div key={m.key}>
+                    <div className="text-xs tracking-widest mb-0.5" style={{ color: m.color }}>{m.label}</div>
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="font-bold" style={{ color: m.color }}>
+                        {Math.round(d.latest * 10) / 10}
+                      </span>
+                      <span className="text-muted-foreground text-xs">{m.unit}</span>
+                      {d.delta != null && d.delta !== 0 && (
+                        <span className="text-xs" style={{ color: up ? '#ff3366' : down ? '#00ff41' : '#6060a0' }}>
+                          {up ? '▲' : '▼'}{Math.abs(Math.round(d.delta * 10) / 10)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </motion.div>
+        )}
+
       </div>
     </div>
   );

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -9,6 +9,7 @@ import userData from './routes/userData';
 import csvImport from './routes/csvImport';
 import aiAnalyze from './routes/aiAnalyze';
 import bodyMeasurements from './routes/bodyMeasurements';
+import statistics from './routes/statistics';
 
 const base = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -37,6 +38,7 @@ const app = base
   .route('/api/csv', csvImport)
   .route('/api/ai', aiAnalyze)
   .route('/api/body-measurements', bodyMeasurements)
+  .route('/api/statistics', statistics)
   .get('/health', (c) => c.json({ ok: true }));
 
 export default app;

--- a/cloudflare/src/lib/nutritionSql.ts
+++ b/cloudflare/src/lib/nutritionSql.ts
@@ -1,0 +1,26 @@
+// 栄養素の日次集計で共有する SQL 断片。
+//
+// log_items から栄養値を取り出す base CTE。FoodMaster が結合できればそれを優先し、
+// 無ければ nutrition_snapshot_json を使う（iOS の NutritionSnapshot と同順）。
+// 栄養値は ratio = number_of_servings / portion_size で按分するため、
+// 集計側（SUM 等）と組み合わせて使う。bind 順は user_id, from, to。
+export const NUTRITION_BASE_CTE = `base AS (
+  SELECT li.log_date AS log_date, li.meal_type AS meal_type,
+    li.number_of_servings AS s,
+    COALESCE(fm.calories,      json_extract(li.nutrition_snapshot_json, '$.calories'))     AS cal,
+    COALESCE(fm.protein,       json_extract(li.nutrition_snapshot_json, '$.protein'))      AS pro,
+    COALESCE(fm.fat,           json_extract(li.nutrition_snapshot_json, '$.fat'))          AS fat,
+    COALESCE(fm.net_carbs,     json_extract(li.nutrition_snapshot_json, '$.netCarbs'))     AS nc,
+    COALESCE(fm.dietary_fiber, json_extract(li.nutrition_snapshot_json, '$.dietaryFiber')) AS fib,
+    COALESCE(fm.portion_size,  json_extract(li.nutrition_snapshot_json, '$.portionSize'))  AS psize
+  FROM log_items li
+  LEFT JOIN food_masters fm ON fm.id = li.food_master_id
+  WHERE li.user_id = ? AND li.log_date >= ? AND li.log_date <= ?
+)`;
+
+// base CTE の按分済み栄養値を SUM する SELECT 列（GROUP BY と組み合わせて使う）。
+export const NUTRITION_SUM_COLUMNS = `SUM(CASE WHEN psize > 0 THEN cal * s / psize ELSE 0 END) AS calories,
+  SUM(CASE WHEN psize > 0 THEN pro * s / psize ELSE 0 END) AS protein,
+  SUM(CASE WHEN psize > 0 THEN fat * s / psize ELSE 0 END) AS fat,
+  SUM(CASE WHEN psize > 0 THEN nc  * s / psize ELSE 0 END) AS netCarbs,
+  SUM(CASE WHEN psize > 0 THEN fib * s / psize ELSE 0 END) AS dietaryFiber`;

--- a/cloudflare/src/routes/logItems.ts
+++ b/cloudflare/src/routes/logItems.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Bindings, Variables, LogItemRow, FoodMasterRow } from '../types';
 import { logItemToResponse } from '../types';
 import { authMiddleware } from '../middleware/auth';
+import { NUTRITION_BASE_CTE, NUTRITION_SUM_COLUMNS } from '../lib/nutritionSql';
 
 type LogItemJoinRow = LogItemRow & {
   fm_id: string | null;
@@ -88,25 +89,9 @@ const logItems = new Hono<{ Bindings: Bindings; Variables: Variables }>()
     }
 
     const { results } = await c.env.DB.prepare(
-      `WITH base AS (
-         SELECT li.log_date AS log_date, li.meal_type AS meal_type,
-           li.number_of_servings AS s,
-           COALESCE(fm.calories,      json_extract(li.nutrition_snapshot_json, '$.calories'))     AS cal,
-           COALESCE(fm.protein,       json_extract(li.nutrition_snapshot_json, '$.protein'))      AS pro,
-           COALESCE(fm.fat,           json_extract(li.nutrition_snapshot_json, '$.fat'))          AS fat,
-           COALESCE(fm.net_carbs,     json_extract(li.nutrition_snapshot_json, '$.netCarbs'))     AS nc,
-           COALESCE(fm.dietary_fiber, json_extract(li.nutrition_snapshot_json, '$.dietaryFiber')) AS fib,
-           COALESCE(fm.portion_size,  json_extract(li.nutrition_snapshot_json, '$.portionSize'))  AS psize
-         FROM log_items li
-         LEFT JOIN food_masters fm ON fm.id = li.food_master_id
-         WHERE li.user_id = ? AND li.log_date >= ? AND li.log_date <= ?
-       )
+      `WITH ${NUTRITION_BASE_CTE}
        SELECT log_date, meal_type,
-         SUM(CASE WHEN psize > 0 THEN cal * s / psize ELSE 0 END) AS calories,
-         SUM(CASE WHEN psize > 0 THEN pro * s / psize ELSE 0 END) AS protein,
-         SUM(CASE WHEN psize > 0 THEN fat * s / psize ELSE 0 END) AS fat,
-         SUM(CASE WHEN psize > 0 THEN nc  * s / psize ELSE 0 END) AS netCarbs,
-         SUM(CASE WHEN psize > 0 THEN fib * s / psize ELSE 0 END) AS dietaryFiber
+         ${NUTRITION_SUM_COLUMNS}
        FROM base
        GROUP BY log_date, meal_type
        ORDER BY log_date ASC`

--- a/cloudflare/src/routes/statistics.test.ts
+++ b/cloudflare/src/routes/statistics.test.ts
@@ -1,0 +1,196 @@
+/// <reference types="@cloudflare/vitest-pool-workers" />
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { issueSessionJwt } from '../middleware/auth';
+
+const TEST_SECRET = 'dev-and-test-secret';
+
+beforeAll(async () => {
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS food_masters (
+      id TEXT PRIMARY KEY COLLATE NOCASE,
+      brand_name TEXT NOT NULL DEFAULT '',
+      product_name TEXT NOT NULL,
+      calories REAL NOT NULL DEFAULT 0,
+      dietary_fiber REAL NOT NULL DEFAULT 0,
+      net_carbs REAL NOT NULL DEFAULT 0,
+      fat REAL NOT NULL DEFAULT 0,
+      protein REAL NOT NULL DEFAULT 0,
+      portion_size REAL NOT NULL DEFAULT 1.0,
+      portion_unit TEXT NOT NULL DEFAULT 'g',
+      unique_key TEXT NOT NULL UNIQUE,
+      created_by TEXT NOT NULL
+    )`
+  ).run();
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS log_items (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      log_date TEXT NOT NULL,
+      meal_type TEXT NOT NULL,
+      number_of_servings REAL NOT NULL DEFAULT 1.0,
+      food_master_id TEXT COLLATE NOCASE REFERENCES food_masters(id) ON DELETE SET NULL,
+      nutrition_snapshot_json TEXT,
+      is_master_deleted INTEGER NOT NULL DEFAULT 0
+    )`
+  ).run();
+  await env.DB.prepare(
+    `CREATE TABLE IF NOT EXISTS body_measurements (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      source_date TEXT,
+      measured_at TEXT NOT NULL,
+      measurement_date_raw TEXT,
+      measurement_time_raw TEXT,
+      measurement_index INTEGER,
+      item_count INTEGER,
+      input_method TEXT,
+      weight_kg REAL,
+      body_fat_percent REAL,
+      muscle_mass_kg REAL,
+      muscle_score REAL,
+      visceral_fat_level REAL,
+      basal_metabolism_kcal REAL,
+      metabolic_age INTEGER,
+      bone_mass_kg REAL,
+      body_water_percent REAL,
+      page_url TEXT,
+      UNIQUE(user_id, measured_at)
+    )`
+  ).run();
+});
+
+beforeEach(async () => {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM log_items'),
+    env.DB.prepare('DELETE FROM food_masters'),
+    env.DB.prepare('DELETE FROM body_measurements'),
+  ]);
+});
+
+async function jwtFor(userId: string): Promise<string> {
+  return issueSessionJwt(userId, TEST_SECRET);
+}
+
+async function authedFetch(userId: string, path: string) {
+  return SELF.fetch(`http://localhost${path}`, {
+    headers: { Authorization: `Bearer ${await jwtFor(userId)}` },
+  });
+}
+
+function insertFoodMaster(id: string, vals: { calories?: number; protein?: number; portionSize?: number } = {}) {
+  return env.DB.prepare(
+    `INSERT INTO food_masters
+       (id, product_name, unique_key, created_by, calories, protein, fat, net_carbs, dietary_fiber, portion_size)
+     VALUES (?, ?, ?, 'tester', ?, ?, 0, 0, 0, ?)`
+  ).bind(id, `Food ${id}`, `|Food ${id}|g`, vals.calories ?? 0, vals.protein ?? 0, vals.portionSize ?? 100);
+}
+
+function insertLog(id: string, userId: string, logDate: string, foodMasterId: string, servings: number) {
+  return env.DB.prepare(
+    `INSERT INTO log_items (id, user_id, timestamp, log_date, meal_type, number_of_servings, food_master_id)
+     VALUES (?, ?, ?, ?, 'Breakfast', ?, ?)`
+  ).bind(id, userId, `${logDate}T00:00:00Z`, logDate, servings, foodMasterId);
+}
+
+function insertBody(id: string, userId: string, measuredAt: string, weightKg: number, bodyFat?: number) {
+  return env.DB.prepare(
+    `INSERT INTO body_measurements (id, user_id, measured_at, weight_kg, body_fat_percent)
+     VALUES (?, ?, ?, ?, ?)`
+  ).bind(id, userId, measuredAt, weightKg, bodyFat ?? null);
+}
+
+type DailyRow = {
+  date: string;
+  calories: number; protein: number; fat: number; netCarbs: number; dietaryFiber: number;
+  weightKg: number | null; bodyFatPercent: number | null;
+};
+
+async function getDaily(userId: string, from: string, to: string): Promise<DailyRow[]> {
+  const res = await authedFetch(userId, `/api/statistics/daily?from=${from}&to=${to}`);
+  expect(res.status).toBe(200);
+  const { items } = await res.json<{ items: DailyRow[] }>();
+  return items;
+}
+
+describe('認証', () => {
+  it('未認証は 401', async () => {
+    const res = await SELF.fetch('http://localhost/api/statistics/daily?from=2025-01-01&to=2025-01-31');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/statistics/daily', () => {
+  it('from/to が無ければ 400', async () => {
+    const res = await authedFetch('user-a', '/api/statistics/daily');
+    expect(res.status).toBe(400);
+  });
+
+  it('栄養と体組成が同じ日でマージされる', async () => {
+    await env.DB.batch([
+      insertFoodMaster('f1', { calories: 200, protein: 10, portionSize: 1 }),
+      insertLog('l1', 'user-a', '2025-01-05', 'f1', 1),
+      insertBody('b1', 'user-a', '2025-01-05T09:00:00.000Z', 50.0, 20.0),
+    ]);
+    const items = await getDaily('user-a', '2025-01-01', '2025-01-31');
+    expect(items).toHaveLength(1);
+    expect(items[0].date).toBe('2025-01-05');
+    expect(items[0].calories).toBe(200);
+    expect(items[0].protein).toBe(10);
+    expect(items[0].weightKg).toBe(50.0);
+    expect(items[0].bodyFatPercent).toBe(20.0);
+  });
+
+  it('栄養のみの日は体組成が null、体組成のみの日は栄養が 0', async () => {
+    await env.DB.batch([
+      insertFoodMaster('f1', { calories: 300, portionSize: 1 }),
+      insertLog('l1', 'user-a', '2025-01-05', 'f1', 1),
+      insertBody('b1', 'user-a', '2025-01-10T09:00:00.000Z', 51.0),
+    ]);
+    const items = await getDaily('user-a', '2025-01-01', '2025-01-31');
+    expect(items.map((i) => i.date)).toEqual(['2025-01-05', '2025-01-10']);
+
+    const nutriOnly = items[0];
+    expect(nutriOnly.calories).toBe(300);
+    expect(nutriOnly.weightKg).toBeNull();
+
+    const bodyOnly = items[1];
+    expect(bodyOnly.calories).toBe(0);
+    expect(bodyOnly.weightKg).toBe(51.0);
+  });
+
+  it('同日に複数の体組成計測がある場合は平均される', async () => {
+    await env.DB.batch([
+      insertBody('b1', 'user-a', '2025-01-05T08:00:00.000Z', 50.0, 20.0),
+      insertBody('b2', 'user-a', '2025-01-05T20:00:00.000Z', 52.0, 22.0),
+    ]);
+    const items = await getDaily('user-a', '2025-01-01', '2025-01-31');
+    expect(items).toHaveLength(1);
+    expect(items[0].weightKg).toBe(51.0);
+    expect(items[0].bodyFatPercent).toBe(21.0);
+  });
+
+  it('期間外のデータは含まれず、他ユーザーのデータも混ざらない', async () => {
+    await env.DB.batch([
+      insertBody('b1', 'user-a', '2024-12-31T09:00:00.000Z', 49.0),
+      insertBody('b2', 'user-a', '2025-01-05T09:00:00.000Z', 50.0),
+      insertBody('b3', 'user-a', '2025-02-01T09:00:00.000Z', 53.0),
+      insertBody('b4', 'user-b', '2025-01-05T09:00:00.000Z', 80.0),
+    ]);
+    const items = await getDaily('user-a', '2025-01-01', '2025-01-31');
+    expect(items).toHaveLength(1);
+    expect(items[0].date).toBe('2025-01-05');
+    expect(items[0].weightKg).toBe(50.0);
+  });
+
+  it('結果は date 昇順で返る', async () => {
+    await env.DB.batch([
+      insertBody('b1', 'user-a', '2025-01-20T09:00:00.000Z', 50.0),
+      insertBody('b2', 'user-a', '2025-01-05T09:00:00.000Z', 51.0),
+      insertBody('b3', 'user-a', '2025-01-12T09:00:00.000Z', 52.0),
+    ]);
+    const items = await getDaily('user-a', '2025-01-01', '2025-01-31');
+    expect(items.map((i) => i.date)).toEqual(['2025-01-05', '2025-01-12', '2025-01-20']);
+  });
+});

--- a/cloudflare/src/routes/statistics.ts
+++ b/cloudflare/src/routes/statistics.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono';
+import type { Bindings, Variables } from '../types';
+import { authMiddleware } from '../middleware/auth';
+import { NUTRITION_BASE_CTE, NUTRITION_SUM_COLUMNS } from '../lib/nutritionSql';
+
+// 体組成の集計対象カラム（DB snake_case → レスポンス camelCase）。
+// 体重等は合計に意味が無いため、同日複数計測は日次 AVG で集約する。
+const BODY_AVG_FIELDS: { col: string; key: string }[] = [
+  { col: 'weight_kg',             key: 'weightKg' },
+  { col: 'body_fat_percent',      key: 'bodyFatPercent' },
+  { col: 'muscle_mass_kg',        key: 'muscleMassKg' },
+  { col: 'muscle_score',          key: 'muscleScore' },
+  { col: 'visceral_fat_level',    key: 'visceralFatLevel' },
+  { col: 'basal_metabolism_kcal', key: 'basalMetabolismKcal' },
+  { col: 'metabolic_age',         key: 'metabolicAge' },
+  { col: 'bone_mass_kg',          key: 'boneMassKg' },
+  { col: 'body_water_percent',    key: 'bodyWaterPercent' },
+];
+
+const NUTRIENT_KEYS = ['calories', 'protein', 'fat', 'netCarbs', 'dietaryFiber'] as const;
+
+type NutriRow = { log_date: string } & Record<(typeof NUTRIENT_KEYS)[number], number | null>;
+type BodyRow = { date: string } & Record<string, number | null>;
+
+const statistics = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+  .use('*', authMiddleware)
+  // GET /daily?from&to : 日次の栄養合計と体組成平均をサーバー側でマージして返す。
+  // 統計ページの「栄養素×体組成」相関グラフ／体組成トレンド用。
+  // 生ログを返さず日次集計済みにすることで Worker の CPU 制限を回避する（/log-items/summary と同方針）。
+  .get('/daily', async (c) => {
+    const userId = c.get('userId');
+    const from = c.req.query('from');
+    const to = c.req.query('to');
+    if (!from || !to) {
+      return c.json({ error: 'from and to are required' }, 400);
+    }
+
+    // 栄養（日次合計）。base CTE を meal_type で割らず log_date 単位で合算する。
+    const nutritionQuery = c.env.DB.prepare(
+      `WITH ${NUTRITION_BASE_CTE}
+       SELECT log_date, ${NUTRITION_SUM_COLUMNS}
+       FROM base
+       GROUP BY log_date
+       ORDER BY log_date ASC`
+    ).bind(userId, from, to).all<NutriRow>();
+
+    // 体組成（日次平均）。measured_at は ISO 日時なので substr で日付化して比較・集約する。
+    const bodyAvg = BODY_AVG_FIELDS.map((f) => `AVG(${f.col}) AS ${f.key}`).join(',\n        ');
+    const bodyQuery = c.env.DB.prepare(
+      `SELECT substr(measured_at, 1, 10) AS date,
+        ${bodyAvg}
+       FROM body_measurements
+       WHERE user_id = ? AND substr(measured_at, 1, 10) BETWEEN ? AND ?
+       GROUP BY date
+       ORDER BY date ASC`
+    ).bind(userId, from, to).all<BodyRow>();
+
+    const [{ results: nutriRows }, { results: bodyRows }] = await Promise.all([nutritionQuery, bodyQuery]);
+
+    // 日付キーで両者をマージ（サーバー側）。栄養欠損は 0、体組成欠損は null。
+    const byDate = new Map<string, Record<string, number | null>>();
+    const ensure = (date: string) => {
+      let row = byDate.get(date);
+      if (!row) {
+        row = { calories: 0, protein: 0, fat: 0, netCarbs: 0, dietaryFiber: 0 };
+        for (const f of BODY_AVG_FIELDS) row[f.key] = null;
+        byDate.set(date, row);
+      }
+      return row;
+    };
+
+    for (const r of nutriRows) {
+      const row = ensure(r.log_date);
+      for (const k of NUTRIENT_KEYS) row[k] = r[k] ?? 0;
+    }
+    for (const r of bodyRows) {
+      const row = ensure(r.date);
+      for (const f of BODY_AVG_FIELDS) row[f.key] = r[f.key] ?? null;
+    }
+
+    const items = [...byDate.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([date, v]) => ({ date, ...v }));
+
+    return c.json({ items });
+  });
+
+export default statistics;


### PR DESCRIPTION
## なぜ

体組成計測データ（体重・体脂肪率・筋肉量など）を記録できるようになった（#128）が、統計ページは栄養素のみで、体組成の推移や「栄養摂取と体組成の関係」を確認できなかった。

## なにを

統計ページに **任意の栄養素 × 任意の体組成指標** を同一期間で重ねて見られる相関ダッシュボードを統合した。

### バックエンド（cloudflare/）
- **`GET /api/statistics/daily?from&to`（新規）** — 日次の栄養合計（按分SUM）と体組成日次平均を**サーバー側でマージ**して返す。生ログを返さず日次集計済みにして Worker の CPU 制限を回避（`/log-items/summary` と同方針）。`measured_at` は ISO 日時のため `substr(measured_at,1,10)` で日付化。栄養欠損は `0`、体組成欠損は `null`
- **`src/lib/nutritionSql.ts`（新規）** — 栄養按分の base CTE / SUM 列を共有定数化。`/log-items/summary` と新エンドポイントで再利用（重複排除、出力は不変）
- **`statistics.test.ts`（新規）** — マージ／欠損（0・null）／同日複数計測の平均／期間外・他ユーザー除外／昇順／400 を検証

### フロントエンド（apps/web/）
- **メイングラフを統合** — 旧「栄養素単体トレンド」と相関グラフを `ComposedChart` 1つに統合（栄養素は day=折れ線／week・month=棒、目標線も維持）
- **体組成の折れ線を `BODY: off / WEIGHT / BODY FAT / …` でトグル** — グラフ全体を出し分けるのではなく線の表示/非表示を切り替え。体組成データを持つユーザーにのみトグルを表示
- 体組成の色は栄養素4色（黄/緑/マゼンタ/シアン）と被らない系統にし、既定 WEIGHT は黄色のカロリー棒とコントラストの出る青系に
- **`BODY COMPOSITION` カード** — 選択期間の最新値＋始端比の差分（▲▼）を表示
- 新規: `hooks/useDailyStats.ts`, `lib/correlation.ts`

### その他
- 個人の体組成データ `measurements.csv`（HealthPlanetエクスポート）を `.gitignore` に追加

## テスト
- cloudflare: `vitest` 全59件パス（新規6件含む）
- apps/web: `bun run build`（tsc + vite）成功
- 本番デプロイ済みで実データ（6320件）で表示確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)